### PR TITLE
Add PSModulePath override to InitialSessionState

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -1664,6 +1664,7 @@ namespace System.Management.Automation.Runspaces
             ss.DefaultCommandVisibility = this.DefaultCommandVisibility;
             ss.AuthorizationManager = this.AuthorizationManager;
             ss.LanguageMode = this.LanguageMode;
+            ss.PSModulePath = this.PSModulePath;
             ss.TranscriptDirectory = this.TranscriptDirectory;
             ss.UserDriveEnabled = this.UserDriveEnabled;
             ss.UserDriveUserName = this.UserDriveUserName;
@@ -1747,6 +1748,12 @@ namespace System.Management.Automation.Runspaces
         /// Specifies the language mode to be used for this session state instance.
         /// </summary>
         public PSLanguageMode LanguageMode { get; set; } = PSLanguageMode.NoLanguage;
+
+        /// <summary>
+        /// Specifies the module search path to use for this session state instance.
+        /// If unset, PowerShell uses the existing environment and configuration-based behavior.
+        /// </summary>
+        public string PSModulePath { get; set; } = null;
 
         /// <summary>
         /// Specifies the directory to be used for collection session transcripts.

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -643,7 +643,7 @@ namespace Microsoft.PowerShell.Commands
 
                 // See if we can use the cached path for the file. If a version number has been specified, then
                 // we won't look in the cache
-                if (this.MinimumVersion == null && this.MaximumVersion == null && this.RequiredVersion == null && PSModuleInfo.UseAppDomainLevelModuleCache && !this.BaseForce)
+                if (this.MinimumVersion == null && this.MaximumVersion == null && this.RequiredVersion == null && PSModuleInfo.UseAppDomainLevelModuleCache && !this.BaseForce && !ModuleIntrinsics.HasCustomPSModulePath(this.Context))
                 {
                     // See if the name is in the appdomain-level module path name cache...
                     cachedPath = PSModuleInfo.ResolveUsingAppDomainLevelModuleCache(name);

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -6108,7 +6108,7 @@ namespace Microsoft.PowerShell.Commands
 
             // If using AppDomain-level module path caching, add this module to the cache. This is only done for
             // the modules loaded with without version info or other qualifiers.
-            if (PSModuleInfo.UseAppDomainLevelModuleCache && module != null && moduleBase == null && this.AddToAppDomainLevelCache)
+            if (PSModuleInfo.UseAppDomainLevelModuleCache && module != null && moduleBase == null && this.AddToAppDomainLevelCache && !ModuleIntrinsics.HasCustomPSModulePath(this.Context))
             {
                 // Cache using the actual name specified by the user rather than the module basename
                 PSModuleInfo.AddToAppDomainLevelModuleCache(module.Name, fileName, this.BaseForce);

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1298,6 +1298,21 @@ namespace System.Management.Automation
             return currentModulePath;
         }
 
+        internal static bool HasCustomPSModulePath(ExecutionContext context)
+        {
+            return context?.InitialSessionState?.PSModulePath != null;
+        }
+
+        private static string ResolveModulePath(ExecutionContext context)
+        {
+            if (HasCustomPSModulePath(context))
+            {
+                return context.InitialSessionState.PSModulePath;
+            }
+
+            return Environment.GetEnvironmentVariable(Constants.PSModulePathEnvVar) ?? SetModulePath();
+        }
+
 #if !UNIX
         /// <summary>
         /// Returns a PSModulePath suitable for Windows PowerShell by removing PowerShell's specific
@@ -1386,7 +1401,8 @@ namespace System.Management.Automation
         /// Include The system wide module path ($PSHOME\Modules) even if it's not in PSModulePath.
         /// In V3-V5, we prepended this path during module auto-discovery which incorrectly preferred
         /// $PSHOME\Modules over user installed modules that might have a command that overrides
-        /// a product-supplied command.
+        /// a product-supplied command. Setting InitialSessionState.PSModulePath will override this behavior
+        /// and will not include the $PSHOME\Modules path at all.
         /// For 5.1, we append $PSHOME\Modules in this case to avoid the rare case where PSModulePath
         /// does not contain the path, but a script depends on previous behavior.
         /// Note that appending is still a potential breaking change, but necessary to update in-box
@@ -1396,7 +1412,7 @@ namespace System.Management.Automation
         /// <returns>The module path as an array of strings.</returns>
         internal static IEnumerable<string> GetModulePath(bool includeSystemModulePath, ExecutionContext context)
         {
-            string modulePathString = Environment.GetEnvironmentVariable(Constants.PSModulePathEnvVar) ?? SetModulePath();
+            string modulePathString = ResolveModulePath(context);
 
             HashSet<string> processedPathSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -1410,7 +1426,7 @@ namespace System.Management.Automation
                 }
             }
 
-            if (includeSystemModulePath)
+            if (includeSystemModulePath && !HasCustomPSModulePath(context))
             {
                 var processedPath = ProcessOneModulePath(context, GetPSHomeModulePath(), processedPathSet);
                 if (processedPath != null)

--- a/test/powershell/engine/Api/InitialSessionState.Tests.ps1
+++ b/test/powershell/engine/Api/InitialSessionState.Tests.ps1
@@ -95,6 +95,59 @@ Describe "TypeTable duplicate types in reused runspace InitialSessionState TypeT
         }
     }
 
+    Describe "InitialSessionState clone" -Tags CI {
+
+        Context "Cloned Properties Test" {
+
+            It "should clone PSModulePath" {
+                [initialsessionstate] $iss = [initialsessionstate]::Create()
+                $iss.PSModulePath = "test"
+                $issReused = $iss.Clone()
+                $issReused.PSModulePath | Should -Be $iss.PSModulePath
+                $issReused.PSModulePath = "changed"
+                $issReused.PSModulePath | Should -Not -Be $iss.PSModulePath
+            }
+
+        }
+
+    }
+
+    Describe "InitialSessionState PSModulePath" -Tags CI {
+
+        Context "Validate PSModulePath in InitialSessionState" {
+
+            BeforeAll {
+
+                [initialsessionstate] $iss = [initialsessionstate]::CreateDefault()
+                $iss.PSModulePath = [string]::Empty
+                $ps = [PowerShell]::Create($iss)
+
+            }
+
+            AfterAll {
+
+                if ($null -ne $ps) { $ps.Dispose() }
+            }
+
+            It "should not load modules from `$PSHome\Modules when PSModulePath is set to empty string" {
+
+                $ps.Commands.Clear()
+                $availableModules = $ps.AddCommand('Get-Module').AddParameter('ListAvailable').Invoke()
+                $availableModules | Should -BeNullOrEmpty
+                $ps.Streams.Error | Should -BeNullOrEmpty
+
+                $ps.Commands.Clear()
+                $ps.Streams.Error.Clear()
+                $null = $ps.AddCommand('Get-Command').AddArgument('Start-ThreadJob').Invoke()
+                $ps.HadErrors | Should -BeTrue
+                $ps.Streams.Error[0].FullyQualifiedErrorId | Should -BeExactly 'CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand'
+
+            }
+
+        }
+
+    }
+
     Context "Cannot use shared TypeTable in ISS test" {
 
         BeforeAll {

--- a/test/xUnit/csharp/test_Runspace.cs
+++ b/test/xUnit/csharp/test_Runspace.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.IO;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using System.Reflection;
@@ -102,6 +103,151 @@ namespace PSTests.Sequential
             }
         }
 
+        [Fact]
+        public void TestRunspaceWithCustomPSModulePathOverride()
+        {
+            WithTestModule((moduleRoot, moduleName, functionName) =>
+            {
+                InitialSessionState iss = CreateInitialSessionStateForModuleImport();
+                iss.PSModulePath = moduleRoot;
+
+                using (Runspace runspace = RunspaceFactory.CreateRunspace(iss))
+                {
+                    runspace.Open();
+                    Assert.Equal(functionName, InvokeModuleFunction(runspace, moduleName, functionName));
+                    runspace.Close();
+                }
+            });
+        }
+
+        [Fact]
+        public void TestRunspaceCustomPSModulePathOverrideDoesNotLeakThroughModuleCache()
+        {
+            bool originalUseAppDomainLevelModuleCache = PSModuleInfo.UseAppDomainLevelModuleCache;
+            PSModuleInfo.UseAppDomainLevelModuleCache = true;
+            PSModuleInfo.ClearAppDomainLevelModulePathCache();
+
+            try
+            {
+                WithTestModule((moduleRoot, moduleName, functionName) =>
+                {
+                    InitialSessionState customIss = CreateInitialSessionStateForModuleImport();
+                    customIss.PSModulePath = moduleRoot;
+
+                    using (Runspace runspace = RunspaceFactory.CreateRunspace(customIss))
+                    {
+                        runspace.Open();
+                        Assert.Equal(functionName, InvokeModuleFunction(runspace, moduleName, functionName));
+                        runspace.Close();
+                    }
+
+                    using (Runspace runspace = RunspaceFactory.CreateRunspace(InitialSessionState.CreateDefault()))
+                    {
+                        runspace.Open();
+
+                        using (PowerShell powerShell = PowerShell.Create())
+                        {
+                            powerShell.Runspace = runspace;
+                            powerShell.AddScript($"Import-Module '{moduleName}' -PassThru -ErrorAction Ignore | Select-Object -ExpandProperty Name");
+
+                            var results = powerShell.Invoke();
+
+                            Assert.Empty(results);
+                        }
+
+                        runspace.Close();
+                    }
+                });
+            }
+            finally
+            {
+                PSModuleInfo.ClearAppDomainLevelModulePathCache();
+                PSModuleInfo.UseAppDomainLevelModuleCache = originalUseAppDomainLevelModuleCache;
+            }
+        }
+
+        [Fact]
+        public void TestRunspaceDefaultPSModulePathOverrideDoesNotLeakThroughModuleCache()
+        {
+            bool originalUseAppDomainLevelModuleCache = PSModuleInfo.UseAppDomainLevelModuleCache;
+            string originalProcessModulePath = Environment.GetEnvironmentVariable("PSModulePath");
+            PSModuleInfo.UseAppDomainLevelModuleCache = true;
+            PSModuleInfo.ClearAppDomainLevelModulePathCache();
+
+            try
+            {
+                WithTestModule((moduleRoot, moduleName, functionName) =>
+                {
+                    string processModulePath = string.IsNullOrEmpty(originalProcessModulePath)
+                        ? moduleRoot
+                        : string.Concat(moduleRoot, Path.PathSeparator, originalProcessModulePath);
+
+                    Environment.SetEnvironmentVariable("PSModulePath", processModulePath);
+
+                    InitialSessionState customIss = CreateInitialSessionStateForModuleImport();
+                    customIss.PSModulePath = string.Empty;
+
+                    using (Runspace runspace = RunspaceFactory.CreateRunspace(CreateInitialSessionStateForModuleImport()))
+                    {
+                        runspace.Open();
+                        Assert.Equal(functionName, InvokeModuleFunction(runspace, moduleName, functionName));
+                        runspace.Close();
+                    }
+
+                    using (Runspace runspace = RunspaceFactory.CreateRunspace(customIss))
+                    {
+                        runspace.Open();
+
+                        using (PowerShell powerShell = PowerShell.Create())
+                        {
+                            powerShell.Runspace = runspace;
+                            powerShell.AddScript($"Import-Module '{moduleName}' -PassThru -ErrorAction Ignore | Select-Object -ExpandProperty Name");
+
+                            var results = powerShell.Invoke();
+
+                            Assert.Empty(results);
+                        }
+
+                        runspace.Close();
+                    }
+                });
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("PSModulePath", originalProcessModulePath);
+                PSModuleInfo.ClearAppDomainLevelModulePathCache();
+                PSModuleInfo.UseAppDomainLevelModuleCache = originalUseAppDomainLevelModuleCache;
+            }
+        }
+
+        [Fact]
+        public void TestRunspacePoolWithCustomPSModulePathOverride()
+        {
+            WithTestModule((moduleRoot, moduleName, functionName) =>
+            {
+                InitialSessionState iss = CreateInitialSessionStateForModuleImport();
+                iss.PSModulePath = moduleRoot;
+
+                using (RunspacePool runspacePool = RunspaceFactory.CreateRunspacePool(iss))
+                {
+                    runspacePool.Open();
+
+                    using (PowerShell powerShell = PowerShell.Create())
+                    {
+                        powerShell.RunspacePool = runspacePool;
+                        powerShell.AddScript($"Import-Module '{moduleName}' -Force; (Get-Command '{functionName}').Name");
+
+                        var results = powerShell.Invoke();
+
+                        Assert.False(powerShell.HadErrors);
+                        Assert.Equal(functionName, Assert.IsType<string>(Assert.Single(results).BaseObject));
+                    }
+
+                    runspacePool.Close();
+                }
+            });
+        }
+
         [SkippableFact]
         public void TestAppDomainProcessExitEvenHandlerNotLeaking()
         {
@@ -127,6 +273,58 @@ namespace PSTests.Sequential
             eventHandler = (EventHandler)field.GetValue(null);
             delegates = eventHandler.GetInvocationList();
             Assert.DoesNotContain(delegates, d => d.Method.Name == "CurrentDomain_ProcessExit");
+        }
+
+        private static string InvokeModuleFunction(Runspace runspace, string moduleName, string functionName)
+        {
+            using (PowerShell powerShell = PowerShell.Create())
+            {
+                powerShell.Runspace = runspace;
+                powerShell.AddScript($"Import-Module '{moduleName}' -Force; (Get-Command '{functionName}').Name");
+
+                var results = powerShell.Invoke();
+
+                Assert.False(powerShell.HadErrors);
+                return Assert.IsType<string>(Assert.Single(results).BaseObject);
+            }
+        }
+
+        private static InitialSessionState CreateInitialSessionStateForModuleImport()
+        {
+            InitialSessionState iss = InitialSessionState.CreateDefault();
+
+            if (Platform.IsWindows)
+            {
+                iss.ExecutionPolicy = Microsoft.PowerShell.ExecutionPolicy.Bypass;
+            }
+
+            return iss;
+        }
+
+        private static void WithTestModule(Action<string, string, string> testAction)
+        {
+            string moduleRoot = Path.Combine(Path.GetTempPath(), nameof(RunspaceTests), Guid.NewGuid().ToString("N"));
+            string moduleName = $"TestRunspaceModule{Guid.NewGuid():N}";
+            string functionName = $"GetRunspaceMarker{Guid.NewGuid():N}";
+            string moduleDirectory = Path.Combine(moduleRoot, moduleName);
+            string moduleFilePath = Path.Combine(moduleDirectory, $"{moduleName}.psm1");
+
+            Directory.CreateDirectory(moduleDirectory);
+            File.WriteAllText(
+                moduleFilePath,
+                $"function {functionName} {{ '{functionName}' }}{Environment.NewLine}Export-ModuleMember -Function {functionName}{Environment.NewLine}");
+
+            try
+            {
+                testAction(moduleRoot, moduleName, functionName);
+            }
+            finally
+            {
+                if (Directory.Exists(moduleRoot))
+                {
+                    Directory.Delete(moduleRoot, recursive: true);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Import PowerShell/PowerShell#27126 as a downstream commit
- Add InitialSessionState.PSModulePath and use it for module path resolution
- Avoid app-domain module cache reuse when a custom PSModulePath is set
- Add PowerShell and xUnit coverage for custom PSModulePath behavior

## Validation
- dotnet test .\test\xUnit\xUnit.tests.csproj -c Release --filter "FullyQualifiedName~PSTests.Sequential.RunspaceTests" --no-restore
- Parsed test\powershell\engine\Api\InitialSessionState.Tests.ps1 with the PowerShell parser
