### PR TITLE
Sign source-built SDK payloads

### DIFF
--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -1286,18 +1286,30 @@ jobs:
 
           $CandidateRoots = @(
             'ref',
+            'runtimes/unix',
             'runtimes/win',
             'runtimes/win-x64/native',
             'runtimes/win-arm64/native',
+            'runtimes/linux-x64/native',
+            'runtimes/linux-arm64/native',
+            'runtimes/osx-x64/native',
+            'runtimes/osx-arm64/native',
             'tools/apphost/win-x64',
-            'tools/apphost/win-arm64'
+            'tools/apphost/win-arm64',
+            'tools/apphost/linux-x64',
+            'tools/apphost/linux-arm64',
+            'tools/apphost/osx-x64',
+            'tools/apphost/osx-arm64',
+            'buildTransitive/windows-desktop-payload',
+            'contentFiles/any/any/runtimes'
           ) | ForEach-Object { Join-Path $ExpandedPackageRoot $_ }
 
+          $SignableExtensions = @('.dll', '.exe', '.psd1', '.psm1', '.ps1xml', '.ps1')
           $CandidateTargets = @(
             foreach ($CandidateRoot in $CandidateRoots) {
               if (Test-Path -LiteralPath $CandidateRoot -PathType Container) {
                 Get-ChildItem -LiteralPath $CandidateRoot -Recurse -File |
-                  Where-Object { $_.Extension -in @('.dll', '.exe') }
+                  Where-Object { $_.Extension -in $SignableExtensions }
               }
             }
           ) | Sort-Object FullName -Unique
@@ -1305,26 +1317,31 @@ jobs:
           $SigningTargets = [System.Collections.Generic.List[System.IO.FileInfo]]::new()
           foreach ($CandidateTarget in $CandidateTargets) {
             $RelativeTarget = [System.IO.Path]::GetRelativePath($ExpandedPackageRoot, $CandidateTarget.FullName)
-            $VerifyOutput = & psign-tool portable verify-pe $CandidateTarget.FullName 2>&1
-            $VerifyExitCode = $LASTEXITCODE
-            if ($VerifyExitCode -eq 0) {
-              Write-Host "Skipping already-signed Windows binary payload: $RelativeTarget"
-              continue
-            }
-            if (($VerifyOutput -join "`n") -match 'PE has no certificate table') {
-              $SigningTargets.Add($CandidateTarget)
-              continue
+            $FileExtension = [System.IO.Path]::GetExtension($CandidateTarget.Name).ToLowerInvariant()
+            if ($FileExtension -in @('.dll', '.exe')) {
+              $VerifyOutput = & psign-tool portable verify-pe $CandidateTarget.FullName 2>&1
+              $VerifyExitCode = $LASTEXITCODE
+              if ($VerifyExitCode -eq 0) {
+                Write-Host "Skipping already-signed Windows binary payload: $RelativeTarget"
+                continue
+              }
+              if (($VerifyOutput -join "`n") -match 'PE has no certificate table') {
+                $SigningTargets.Add($CandidateTarget)
+                continue
+              }
+
+              $VerifyOutput | ForEach-Object { Write-Host $_ }
+              throw "Unable to determine signing state for Windows binary payload '$RelativeTarget'."
             }
 
-            $VerifyOutput | ForEach-Object { Write-Host $_ }
-            throw "Unable to determine signing state for Windows binary payload '$RelativeTarget'."
+            $SigningTargets.Add($CandidateTarget)
           }
 
           if ($SigningTargets.Count -eq 0) {
-            throw "No Windows binary signing targets were found in $($NugetPackage.Name)."
+            throw "No source-built signing targets were found in $($NugetPackage.Name)."
           }
 
-          Write-Host "Signing $($SigningTargets.Count) Windows binary payload(s) inside $($NugetPackage.Name)."
+          Write-Host "Signing $($SigningTargets.Count) source-built payload(s) inside $($NugetPackage.Name)."
           $SigningArgs = @(
             '--mode', 'portable',
             'sign',

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The local script writes under `output\local-sdk\<rid>\` and produces a single-RI
 
 | Workflow | Purpose | Output |
 | --- | --- | --- |
-| `.github/workflows/powershell-sdk.yml` | Builds PowerShell from source, vendors the source-built PowerShell SDK assemblies into one `Devolutions.PowerShell.SDK` package, signs Windows PE payloads inside it for release, validates it in a sample .NET app with opt-in apphost import, and can publish the validated package. | `PowerShell-SDK-Release-7.6.3.0` artifact containing one `.nupkg`; optional NuGet.org publish plus GitHub release `v7.6.3.0`. |
+| `.github/workflows/powershell-sdk.yml` | Builds PowerShell from source, vendors the source-built PowerShell SDK assemblies into one `Devolutions.PowerShell.SDK` package, signs the source-built payloads inside it for release, validates it in a sample .NET app with opt-in apphost import, and can publish the validated package. | `PowerShell-SDK-Release-7.6.3.0` artifact containing one `.nupkg`; optional NuGet.org publish plus GitHub release `v7.6.3.0`. |
 | `.github/workflows/powershell.yml` | Restores the pinned `Devolutions.PowerShell.SDK` package, imports its apphost and module payload through MSBuild, publishes a self-contained PowerShell layout, and repackages it for Windows, macOS, and Linux on x64 and arm64. | `PowerShell-7.6.3-<os>-<arch>` `.tar.gz` artifacts. |
 | `.github/workflows/dotnet-runtime.yml` | Builds the .NET runtime tag used by this PowerShell release for Windows, macOS, and Linux on x86_64 and arm64 with prebuilt clang+llvm from `awakecoding/llvm-prebuilt`. | Runtime build output in the workflow logs/workspace. |
 
@@ -53,7 +53,7 @@ All workflows are manual and can be started from the GitHub Actions **Run workfl
 
 ## Publishing the PowerShell SDK package
 
-The SDK workflow publishes only after the package has been built, had its Windows PE payloads signed for release, and been validated on every RID in the validation matrix. The release version is `POWERSHELL_VERSION.SDK_PACKAGE_REVISION`, such as `7.6.3.0`.
+The SDK workflow publishes only after the package has been built, had its source-built payloads signed for release, and been validated on every RID in the validation matrix. The release version is `POWERSHELL_VERSION.SDK_PACKAGE_REVISION`, such as `7.6.3.0`.
 
 Manual inputs:
 
@@ -65,7 +65,7 @@ Manual inputs:
 | `dry-run` | Simulates publishing. This defaults to `true`; non-production environments are forced to dry-run when publishing is requested. |
 | `sign-dry-run` | Signs the package during a dry-run when code signing secrets are available. This defaults to `false` so dry-runs can exercise packaging and release flow without requiring signing credentials. |
 
-Before validation and publishing, the SDK workflow runs a signing stage that downloads the built `.nupkg`, installs the pinned `Devolutions/psign` `psign-tool-linux-x64.zip`, verifies its SHA256, extracts the package, signs Windows `.dll` and `.exe` payloads with Azure Key Vault, and repacks the `.nupkg` without adding a NuGet package signature. A non-dry-run publish requires these environment secrets and variables:
+Before validation and publishing, the SDK workflow runs a signing stage that downloads the built `.nupkg`, installs the pinned `Devolutions/psign` `psign-tool-linux-x64.zip`, verifies its SHA256, extracts the package, signs the source-built payloads inside it with Azure Key Vault, and repacks the `.nupkg` without adding a NuGet package signature. The signing pass covers the built PowerShell assemblies in `ref/` and `runtimes/*/lib/`, the apphost payloads in `tools/apphost/*` and `runtimes/*/native`, the Windows desktop payload, and the built-in module manifests/format/script files in `contentFiles/any/any/runtimes/**/Modules/**`. A non-dry-run publish requires these environment secrets and variables:
 
 | Name | Type |
 | --- | --- |


### PR DESCRIPTION
## Summary
- extend the SDK signing pass to include source-built PowerShell payloads beyond Windows PE binaries
- update the workflow documentation to describe the broader signing scope

## Testing
- validated the workflow YAML parses successfully
- ran `git diff --check` on the modified files