### PR TITLE
Use latest psign release

### DIFF
--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -42,8 +42,7 @@ env:
   MULTI_PWSH_APPHOST_PACKAGE_ID: "Devolutions.MultiPwsh.Cli"
   MULTI_PWSH_APPHOST_PACKAGE_VERSION: "0.14.0"
   MULTI_PWSH_APPHOST_PACKAGE_SOURCE: "https://api.nuget.org/v3/index.json"
-  PSIGN_RELEASE_TAG: "v0.5.1"
-  PSIGN_TOOL_LINUX_X64_SHA256: "de293360c1aed93709b80980e1ad47998b2b73f76fae40cf48f08213f862a463"
+  PSIGN_TOOL_LINUX_X64_URL: "https://github.com/Devolutions/psign/releases/latest/download/psign-tool-linux-x64.zip"
 jobs:
   preflight:
     name: Preflight
@@ -1216,7 +1215,7 @@ jobs:
           echo "::notice::SDKCodeSigningSignDryRun: $SignDryRun"
           echo "::notice::SDKPackageWillBeCodeSigned: $ShouldSign"
 
-      - name: Install psign tool
+      - name: Install latest psign tool
         if: steps.signing-mode.outputs.should_sign == 'true'
         shell: pwsh
         run: |
@@ -1227,13 +1226,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path $ToolRoot | Out-Null
 
           $ArchivePath = Join-Path $ToolRoot "psign-tool-linux-x64.zip"
-          $DownloadUrl = "https://github.com/Devolutions/psign/releases/download/$Env:PSIGN_RELEASE_TAG/psign-tool-linux-x64.zip"
-          Invoke-WebRequest -Uri $DownloadUrl -OutFile $ArchivePath
-
-          $ActualHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $ArchivePath).Hash.ToLowerInvariant()
-          if ($ActualHash -ne $Env:PSIGN_TOOL_LINUX_X64_SHA256) {
-            throw "Unexpected psign-tool-linux-x64.zip SHA256 '$ActualHash', expected '$Env:PSIGN_TOOL_LINUX_X64_SHA256'."
-          }
+          Invoke-WebRequest -Uri $Env:PSIGN_TOOL_LINUX_X64_URL -OutFile $ArchivePath
 
           Expand-Archive -Path $ArchivePath -DestinationPath $ToolRoot -Force
           $ToolPath = Join-Path $ToolRoot "psign-tool"
@@ -1243,10 +1236,11 @@ jobs:
 
           chmod +x $ToolPath
           $ToolRoot >> $Env:GITHUB_PATH
-          & $ToolPath --version
+          $VersionOutput = & $ToolPath --version 2>&1
           if ($LASTEXITCODE -ne 0) {
             throw "psign-tool --version failed with exit code $LASTEXITCODE"
           }
+          Write-Host "Installed psign-tool version: $(($VersionOutput | Out-String).Trim())"
 
       - name: Code sign PowerShell SDK package
         shell: pwsh

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The local script writes under `output\local-sdk\<rid>\` and produces a single-RI
 | PowerShell SDK package source | `https://api.nuget.org/v3/index.json` |
 | multi-pwsh apphost package | `Devolutions.MultiPwsh.Cli` / `0.14.0` |
 | multi-pwsh apphost package source | `https://api.nuget.org/v3/index.json` |
-| psign code signing tool | `v0.5.1` |
+| psign code signing tool | `latest release (un-pinned)` |
 | .NET runtime workflow | `v10.0.5` |
 | llvm-prebuilt | `v2026.1.1` |
 | clang+llvm | `22.1.4` |
@@ -65,7 +65,7 @@ Manual inputs:
 | `dry-run` | Simulates publishing. This defaults to `true`; non-production environments are forced to dry-run when publishing is requested. |
 | `sign-dry-run` | Signs the package during a dry-run when code signing secrets are available. This defaults to `false` so dry-runs can exercise packaging and release flow without requiring signing credentials. |
 
-Before validation and publishing, the SDK workflow runs a signing stage that downloads the built `.nupkg`, installs the pinned `Devolutions/psign` `psign-tool-linux-x64.zip`, verifies its SHA256, extracts the package, signs the source-built payloads inside it with Azure Key Vault, and repacks the `.nupkg` without adding a NuGet package signature. The signing pass covers the built PowerShell assemblies in `ref/` and `runtimes/*/lib/`, the apphost payloads in `tools/apphost/*` and `runtimes/*/native`, the Windows desktop payload, and the built-in module manifests/format/script files in `contentFiles/any/any/runtimes/**/Modules/**`. A non-dry-run publish requires these environment secrets and variables:
+Before validation and publishing, the SDK workflow runs a signing stage that downloads the built `.nupkg`, installs the latest `Devolutions/psign` `psign-tool-linux-x64.zip`, extracts the package, signs the source-built payloads inside it with Azure Key Vault, and repacks the `.nupkg` without adding a NuGet package signature. The signing pass covers the built PowerShell assemblies in `ref/` and `runtimes/*/lib/`, the apphost payloads in `tools/apphost/*` and `runtimes/*/native`, the Windows desktop payload, and the built-in module manifests/format/script files in `contentFiles/any/any/runtimes/**/Modules/**`. A non-dry-run publish requires these environment secrets and variables:
 
 | Name | Type |
 | --- | --- |


### PR DESCRIPTION
## Summary
- replace the pinned psign release tag and SHA256 env vars with the GitHub latest-download URL
- install the latest psign tool in the SDK workflow and log the resolved version after install
- update the README to reflect that psign is no longer pinned