### PR TITLE
Refactor PowerShell release workflows

### DIFF
--- a/.github/workflows/powershell-cli.yml
+++ b/.github/workflows/powershell-cli.yml
@@ -1,15 +1,36 @@
-name: PowerShell
+name: PowerShell CLI
 on:
   workflow_dispatch:
     inputs:
+      sdk_package_version:
+        description: Optional SDK package version override (blank = use SDK_PACKAGE_VERSION)
+        default: ""
+        required: false
       sdk_artifact_run_id:
         description: Optional SDK workflow run ID whose nupkg artifact should be repackaged instead of SDK_PACKAGE_SOURCE
         default: ""
         required: false
       sdk_artifact_name:
-        description: Optional SDK nupkg artifact name from sdk_artifact_run_id
+        description: Optional SDK nupkg artifact name to repackage instead of SDK_PACKAGE_SOURCE
         default: ""
         required: false
+  workflow_call:
+    inputs:
+      sdk_package_version:
+        description: Optional SDK package version override (blank = use SDK_PACKAGE_VERSION)
+        default: ""
+        required: false
+        type: string
+      sdk_artifact_run_id:
+        description: Optional SDK workflow run ID whose nupkg artifact should be repackaged instead of SDK_PACKAGE_SOURCE
+        default: ""
+        required: false
+        type: string
+      sdk_artifact_name:
+        description: Optional SDK nupkg artifact name to repackage instead of SDK_PACKAGE_SOURCE
+        default: ""
+        required: false
+        type: string
 permissions:
   actions: read
   contents: read
@@ -101,14 +122,24 @@ jobs:
             throw "POWERSHELL_VERSION '$Env:POWERSHELL_VERSION' does not match POWERSHELL_RELEASE_TAG '$Env:POWERSHELL_RELEASE_TAG'."
           }
 
-          $ExpectedSdkPackageVersion = "$Env:POWERSHELL_VERSION.$Env:SDK_PACKAGE_REVISION"
-          if ($Env:SDK_PACKAGE_VERSION -ne $ExpectedSdkPackageVersion) {
-            throw "SDK_PACKAGE_VERSION '$Env:SDK_PACKAGE_VERSION' does not match POWERSHELL_VERSION.SDK_PACKAGE_REVISION '$ExpectedSdkPackageVersion'."
+          $SdkPackageVersion = '${{ inputs.sdk_package_version }}'.Trim()
+          if ([string]::IsNullOrWhiteSpace($SdkPackageVersion)) {
+            $SdkArtifactName = '${{ inputs.sdk_artifact_name }}'.Trim()
+            if ($SdkArtifactName -match '^PowerShell-SDK-Release-(\d+\.\d+\.\d+\.\d+)$') {
+              $SdkPackageVersion = $Matches[1]
+            } else {
+              $SdkPackageVersion = $Env:SDK_PACKAGE_VERSION
+            }
+          }
+
+          $EscapedPowerShellVersion = [regex]::Escape($Env:POWERSHELL_VERSION)
+          if ($SdkPackageVersion -notmatch "^$EscapedPowerShellVersion\.\d+$") {
+            throw "SDK package version '$SdkPackageVersion' does not match expected PowerShell version prefix '$Env:POWERSHELL_VERSION'."
           }
 
           $SourceCommit = (Invoke-GitPowerShell rev-parse HEAD).Trim()
           Write-Host "PowerShell source: $Env:POWERSHELL_SOURCE_REPOSITORY@$Env:POWERSHELL_SOURCE_REF ($SourceCommit)"
-          Write-Host "PowerShell SDK package: $Env:SDK_PACKAGE_ID $Env:SDK_PACKAGE_VERSION from $Env:SDK_PACKAGE_SOURCE"
+          Write-Host "PowerShell SDK package: $Env:SDK_PACKAGE_ID $SdkPackageVersion from $Env:SDK_PACKAGE_SOURCE"
 
           $BaseRef = if ($Env:POWERSHELL_SOURCE_REPOSITORY -eq $Env:GITHUB_REPOSITORY) {
             $Env:POWERSHELL_UPSTREAM_TAG
@@ -130,12 +161,19 @@ jobs:
         with:
           global-json-file: pwsh-src/global.json
 
-      - name: Download workflow-built SDK package
+      - name: Download current-run SDK package
+        if: ${{ inputs.sdk_artifact_name != '' && inputs.sdk_artifact_run_id == '' }}
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: ${{ inputs.sdk_artifact_name }}
+          path: sdk-package-source
+
+      - name: Download previous-run SDK package
         if: ${{ inputs.sdk_artifact_run_id != '' }}
         uses: actions/download-artifact@v8.0.1
         with:
           run-id: ${{ inputs.sdk_artifact_run_id }}
-          name: ${{ inputs.sdk_artifact_name || format('PowerShell-SDK-Release-{0}', env.SDK_PACKAGE_VERSION) }}
+          name: ${{ inputs.sdk_artifact_name || format('PowerShell-SDK-Release-{0}', inputs.sdk_package_version || env.SDK_PACKAGE_VERSION) }}
           path: sdk-package-source
           github-token: ${{ github.token }}
 
@@ -148,13 +186,24 @@ jobs:
           $ArchivePath = "$OutputPath.tar.gz"
           $PackageScript = Join-Path (Join-Path $PWD 'eng') 'New-PowerShellDistroArchive.ps1'
           $PackageSource = $Env:SDK_PACKAGE_SOURCE
+          $SdkPackageVersion = '${{ inputs.sdk_package_version }}'.Trim()
+          if ([string]::IsNullOrWhiteSpace($SdkPackageVersion)) {
+            $SdkArtifactName = '${{ inputs.sdk_artifact_name }}'.Trim()
+            if ($SdkArtifactName -match '^PowerShell-SDK-Release-(\d+\.\d+\.\d+\.\d+)$') {
+              $SdkPackageVersion = $Matches[1]
+            } else {
+              $SdkPackageVersion = $Env:SDK_PACKAGE_VERSION
+            }
+          }
 
           $SdkArtifactRunId = '${{ inputs.sdk_artifact_run_id }}'.Trim()
-          if ($SdkArtifactRunId) {
+          $SdkArtifactName = '${{ inputs.sdk_artifact_name }}'.Trim()
+          if ($SdkArtifactName -or $SdkArtifactRunId) {
             $PackageSource = Join-Path $PWD 'sdk-package-source'
             $SdkPackages = @(Get-ChildItem -LiteralPath $PackageSource -Filter "$($Env:SDK_PACKAGE_ID).*nupkg" -File)
             if ($SdkPackages.Count -ne 1) {
-              throw "Expected exactly one $Env:SDK_PACKAGE_ID nupkg from SDK workflow run '$SdkArtifactRunId', found $($SdkPackages.Count)."
+              $SourceDescription = if ($SdkArtifactRunId) { "SDK workflow run '$SdkArtifactRunId'" } else { "current workflow run artifact '$SdkArtifactName'" }
+              throw "Expected exactly one $Env:SDK_PACKAGE_ID nupkg from $SourceDescription, found $($SdkPackages.Count)."
             }
 
             Write-Host "Using workflow-built SDK package: $($SdkPackages[0].FullName)"
@@ -164,7 +213,7 @@ jobs:
 
           & $PackageScript `
             -PackageId $Env:SDK_PACKAGE_ID `
-            -PackageVersion $Env:SDK_PACKAGE_VERSION `
+            -PackageVersion $SdkPackageVersion `
             -PackageSource $PackageSource `
             -PowerShellVersion $Env:POWERSHELL_VERSION `
             -RuntimeIdentifier '${{matrix.rid}}' `

--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -420,6 +420,16 @@ jobs:
               '</configuration>'
             )
             Set-Content -Path "./src/Modules/nuget.config" -Value $ModuleNugetConfig -Encoding utf8
+
+            $GlobalToolShimProjectPath = "./src/Microsoft.PowerShell.GlobalTool.Shim/Microsoft.PowerShell.GlobalTool.Shim.csproj"
+            $GlobalToolShimProject = Get-Content -LiteralPath $GlobalToolShimProjectPath -Raw
+            $WindowsDesktopShimImport = 'Sdk="Microsoft.NET.Sdk.WindowsDesktop" Condition="''$(SDKToUse)'' == ''Microsoft.NET.Sdk.WindowsDesktop'' "'
+            if (-not $GlobalToolShimProject.Contains($WindowsDesktopShimImport)) {
+              throw "Unable to find expected WindowsDesktop SDK imports in $GlobalToolShimProjectPath"
+            }
+
+            $PatchedGlobalToolShimProject = $GlobalToolShimProject.Replace($WindowsDesktopShimImport, 'Sdk="Microsoft.NET.Sdk" Condition="''$(SDKToUse)'' == ''Microsoft.NET.Sdk.WindowsDesktop'' "')
+            Set-Content -LiteralPath $GlobalToolShimProjectPath -Value $PatchedGlobalToolShimProject -Encoding utf8NoBOM
           }
 
           [xml]$CommonProps = Get-Content ./PowerShell.Common.props

--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -16,7 +16,7 @@ on:
           - prod
         default: auto
       skip-publish:
-        description: Skip NuGet and GitHub Release publishing
+        description: Skip downstream publishing when called by release.yml
         required: true
         type: boolean
         default: false
@@ -30,6 +30,78 @@ on:
         required: true
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      sdk_package_revision:
+        description: Downstream SDK package revision override (blank = use SDK_PACKAGE_REVISION, auto = infer next release revision)
+        default: ""
+        required: false
+        type: string
+      github-env:
+        description: GitHub environment selection
+        required: false
+        type: string
+        default: auto
+      skip-publish:
+        description: Skip downstream publishing in the caller
+        required: false
+        type: boolean
+        default: false
+      dry-run:
+        description: Dry run (simulate publishing)
+        required: false
+        type: boolean
+        default: true
+      sign-dry-run:
+        description: Sign package during dry-run when code signing secrets are available
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      package-env:
+        description: Selected GitHub publishing environment
+        value: ${{ jobs.preflight.outputs.package-env }}
+      powershell-version:
+        description: PowerShell version
+        value: ${{ jobs.preflight.outputs.powershell-version }}
+      powershell-release-tag:
+        description: PowerShell upstream release tag
+        value: ${{ jobs.preflight.outputs.powershell-release-tag }}
+      powershell-source-ref:
+        description: Downstream PowerShell source ref
+        value: ${{ jobs.preflight.outputs.powershell-source-ref }}
+      powershell-source-commit:
+        description: Checked-out PowerShell source commit
+        value: ${{ jobs.preflight.outputs.powershell-source-commit }}
+      sdk-package-version:
+        description: SDK package version
+        value: ${{ jobs.preflight.outputs.sdk-package-version }}
+      sdk-package-artifact:
+        description: Unsigned SDK package artifact name
+        value: ${{ jobs.preflight.outputs.sdk-package-artifact }}
+      release-sdk-package-artifact:
+        description: Release-ready SDK package artifact name
+        value: ${{ jobs.preflight.outputs.release-sdk-package-artifact }}
+      release-tag:
+        description: GitHub release tag
+        value: ${{ jobs.preflight.outputs.release-tag }}
+      release-title:
+        description: GitHub release title
+        value: ${{ jobs.preflight.outputs.release-title }}
+      skip-publish:
+        description: Whether downstream publishing should be skipped
+        value: ${{ jobs.preflight.outputs.skip-publish }}
+      dry-run:
+        description: Effective dry-run value
+        value: ${{ jobs.preflight.outputs.dry-run }}
+      code-signed:
+        description: Whether the release SDK package was code signed
+        value: ${{ jobs.sign.outputs.code-signed }}
+
+permissions:
+  actions: read
+  contents: read
+
 env:
   POWERSHELL_VERSION: "7.6.3"
   POWERSHELL_RELEASE_TAG: "v7.6.3"
@@ -49,6 +121,9 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       package-env: ${{ steps.info.outputs.package-env }}
+      powershell-version: ${{ steps.info.outputs.powershell-version }}
+      powershell-release-tag: ${{ steps.info.outputs.powershell-release-tag }}
+      powershell-source-ref: ${{ steps.info.outputs.powershell-source-ref }}
       sdk-package-revision: ${{ steps.info.outputs.sdk-package-revision }}
       sdk-package-version: ${{ steps.info.outputs.sdk-package-version }}
       sdk-package-artifact: ${{ steps.info.outputs.sdk-package-artifact }}
@@ -193,6 +268,9 @@ jobs:
           }
 
           echo "package-env=$PackageEnv" >> $Env:GITHUB_OUTPUT
+          echo "powershell-version=$Env:POWERSHELL_VERSION" >> $Env:GITHUB_OUTPUT
+          echo "powershell-release-tag=$Env:POWERSHELL_RELEASE_TAG" >> $Env:GITHUB_OUTPUT
+          echo "powershell-source-ref=$Env:POWERSHELL_SOURCE_REF" >> $Env:GITHUB_OUTPUT
           echo "sdk-package-revision=$SdkPackageRevision" >> $Env:GITHUB_OUTPUT
           echo "sdk-package-version=$SdkPackageVersion" >> $Env:GITHUB_OUTPUT
           echo "sdk-package-artifact=$SdkPackageArtifact" >> $Env:GITHUB_OUTPUT
@@ -1207,7 +1285,7 @@ jobs:
           $ShouldSign = $HasSigningSecrets -and ($RealPublish -or $SignDryRun)
 
           if ($RealPublish -and -not $HasSigningSecrets) {
-            throw "Azure Key Vault code signing secrets are required for non-dry-run SDK publishing."
+            throw "Azure Key Vault code signing secrets are required for non-dry-run release signing."
           }
 
           echo "should_sign=$($ShouldSign.ToString().ToLower())" >> $Env:GITHUB_OUTPUT
@@ -1445,121 +1523,3 @@ jobs:
             -RuntimeIdentifier ${{matrix.rid}} `
             -PackageId $Env:SDK_PACKAGE_ID `
             -PackageVendorName $Env:SDK_VENDOR_NAME
-
-  publish:
-    name: Publish PowerShell SDK
-    runs-on: ubuntu-24.04
-    needs: [preflight, sign, validate]
-    if: ${{ fromJSON(needs.preflight.outputs.skip-publish) == false }}
-    environment: ${{ needs.preflight.outputs.package-env }}
-    permissions:
-      id-token: write
-      contents: write
-
-    steps:
-      - name: Download PowerShell SDK package
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: ${{ needs.preflight.outputs.release-sdk-package-artifact }}
-          path: package
-
-      - name: NuGet login (OIDC)
-        if: ${{ fromJSON(needs.preflight.outputs.dry-run) == false }}
-        id: nuget-login
-        uses: NuGet/login@v1
-        with:
-          user: ${{ secrets.NUGET_BOT_USERNAME }}
-
-      - name: Publish to nuget.org
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-
-          $DryRun = [System.Boolean]::Parse('${{ needs.preflight.outputs.dry-run }}')
-          $NuGetApiKey = '${{ steps.nuget-login.outputs.NUGET_API_KEY }}'
-          $NugetPackages = @(Get-ChildItem -Path ./package -Filter *.nupkg -File | Sort-Object Name)
-          if ($NugetPackages.Count -ne 1) {
-            throw "Expected exactly one SDK .nupkg in ./package, found $($NugetPackages.Count)."
-          }
-
-          foreach ($NugetPackage in $NugetPackages) {
-            $PackagePath = Resolve-Path -LiteralPath $NugetPackage.FullName -Relative
-            Write-Host "Publishing $PackagePath to nuget.org"
-
-            if ($DryRun) {
-              Write-Host "Dry Run: skipping nuget.org publishing!"
-              continue
-            }
-
-            if ([string]::IsNullOrWhiteSpace($NuGetApiKey)) {
-              throw "NuGet/login did not provide a NuGet API key."
-            }
-
-            $PushArgs = @(
-              'nuget', 'push', $PackagePath,
-              '--api-key', $NuGetApiKey,
-              '--source', 'https://api.nuget.org/v3/index.json',
-              '--skip-duplicate', '--no-symbols'
-            )
-            & dotnet @PushArgs
-            if ($LASTEXITCODE -ne 0) {
-              throw "dotnet nuget push failed for $PackagePath with exit code $LASTEXITCODE"
-            }
-          }
-
-      - name: Create GitHub release
-        shell: pwsh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        working-directory: package
-        run: |
-          $ErrorActionPreference = 'Stop'
-
-          $DryRun = [System.Boolean]::Parse('${{ needs.preflight.outputs.dry-run }}')
-          $PackageVersion = '${{ needs.preflight.outputs.sdk-package-version }}'
-          $ReleaseTag = '${{ needs.preflight.outputs.release-tag }}'
-          $ReleaseTitle = '${{ needs.preflight.outputs.release-title }}'
-          $Repository = $Env:GITHUB_REPOSITORY
-          $SourceCommit = '${{ needs.preflight.outputs.powershell-source-commit }}'
-          $CodeSigned = '${{ needs.sign.outputs.code-signed }}'
-
-          $NugetPackages = @(Get-ChildItem -Filter *.nupkg -File | Sort-Object Name)
-          if ($NugetPackages.Count -ne 1) {
-            throw "Expected exactly one SDK .nupkg in the release package directory, found $($NugetPackages.Count)."
-          }
-
-          $HashPath = 'checksums'
-          $ChecksumLines = foreach ($NugetPackage in $NugetPackages) {
-            $Hash = Get-FileHash -Algorithm SHA256 -LiteralPath $NugetPackage.FullName
-            "$($Hash.Hash)  $($NugetPackage.Name)"
-          }
-          Set-Content -Path $HashPath -Value $ChecksumLines -Encoding ASCII
-
-          echo "::group::checksums"
-          Get-Content $HashPath
-          echo "::endgroup::"
-
-          $NotesPath = 'release-notes.md'
-          $ReleaseNotes = @(
-            "# $ReleaseTitle",
-            "",
-            "| Field | Value |",
-            "| --- | --- |",
-            "| Package ID | $Env:SDK_PACKAGE_ID |",
-            "| Package version | $PackageVersion |",
-            "| PowerShell upstream release | $Env:POWERSHELL_RELEASE_TAG |",
-            "| PowerShell downstream source ref | $Env:POWERSHELL_SOURCE_REF |",
-            "| PowerShell source commit | $SourceCommit |",
-            "| Code signed | $CodeSigned |"
-          )
-          Set-Content -Path $NotesPath -Value $ReleaseNotes -Encoding utf8
-
-          if ($DryRun) {
-            Write-Host "Dry Run: skipping GitHub release!"
-          } else {
-            $ReleaseAssets = @($NugetPackages | ForEach-Object { $_.Name }) + $HashPath
-            & gh release create $ReleaseTag --repo $Repository --target $Env:GITHUB_SHA --title $ReleaseTitle --notes-file $NotesPath @ReleaseAssets
-            if ($LASTEXITCODE -ne 0) {
-              throw "gh release create failed for $ReleaseTag with exit code $LASTEXITCODE"
-            }
-          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,12 @@
 name: PowerShell Release
 on:
+  push:
+    branches:
+      - refactor-release-workflows
+    paths:
+      - ".github/workflows/release.yml"
+      - ".github/workflows/powershell-sdk.yml"
+      - ".github/workflows/powershell-cli.yml"
   workflow_dispatch:
     inputs:
       sdk_package_revision:
@@ -47,11 +54,11 @@ jobs:
       actions: read
       contents: read
     with:
-      sdk_package_revision: ${{ inputs.sdk_package_revision }}
-      github-env: ${{ inputs.github-env }}
-      skip-publish: ${{ inputs.skip-publish }}
-      dry-run: ${{ inputs.dry-run }}
-      sign-dry-run: ${{ inputs.sign-dry-run }}
+      sdk_package_revision: ${{ github.event_name == 'workflow_dispatch' && inputs.sdk_package_revision || '' }}
+      github-env: ${{ github.event_name == 'workflow_dispatch' && inputs.github-env || 'auto' }}
+      skip-publish: ${{ github.event_name == 'workflow_dispatch' && inputs.skip-publish }}
+      dry-run: ${{ github.event_name != 'workflow_dispatch' || inputs.dry-run }}
+      sign-dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.sign-dry-run }}
     secrets: inherit
 
   cli:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,202 @@
+name: PowerShell Release
+on:
+  workflow_dispatch:
+    inputs:
+      sdk_package_revision:
+        description: Downstream SDK package revision override (blank = use SDK_PACKAGE_REVISION, auto = infer next release revision)
+        default: ""
+        required: false
+      github-env:
+        description: GitHub environment selection
+        required: true
+        type: choice
+        options:
+          - auto
+          - test
+          - prod
+        default: auto
+      skip-publish:
+        description: Skip NuGet and GitHub Release publishing
+        required: true
+        type: boolean
+        default: false
+      dry-run:
+        description: Dry run (simulate publishing)
+        required: true
+        type: boolean
+        default: true
+      sign-dry-run:
+        description: Sign package during dry-run when signing secrets are available
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  actions: read
+  contents: read
+
+env:
+  SDK_PACKAGE_ID: "Devolutions.PowerShell.SDK"
+  SDK_PACKAGE_SOURCE: "https://api.nuget.org/v3/index.json"
+
+jobs:
+  sdk:
+    name: Build PowerShell SDK
+    uses: ./.github/workflows/powershell-sdk.yml
+    permissions:
+      actions: read
+      contents: read
+    with:
+      sdk_package_revision: ${{ inputs.sdk_package_revision }}
+      github-env: ${{ inputs.github-env }}
+      skip-publish: ${{ inputs.skip-publish }}
+      dry-run: ${{ inputs.dry-run }}
+      sign-dry-run: ${{ inputs.sign-dry-run }}
+    secrets: inherit
+
+  cli:
+    name: Build PowerShell CLI
+    needs: sdk
+    uses: ./.github/workflows/powershell-cli.yml
+    permissions:
+      actions: read
+      contents: read
+    with:
+      sdk_package_version: ${{ needs.sdk.outputs.sdk-package-version }}
+      sdk_artifact_name: ${{ needs.sdk.outputs.release-sdk-package-artifact }}
+    secrets: inherit
+
+  publish:
+    name: Publish PowerShell release
+    runs-on: ubuntu-24.04
+    needs: [sdk, cli]
+    if: ${{ fromJSON(needs.sdk.outputs.skip-publish) == false }}
+    environment: ${{ needs.sdk.outputs.package-env }}
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Download PowerShell SDK package
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: ${{ needs.sdk.outputs.release-sdk-package-artifact }}
+          path: release-assets
+
+      - name: Download PowerShell CLI packages
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: PowerShell-${{ needs.sdk.outputs.powershell-version }}-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: NuGet login (OIDC)
+        if: ${{ fromJSON(needs.sdk.outputs.dry-run) == false }}
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_BOT_USERNAME }}
+
+      - name: Publish to nuget.org
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $DryRun = [System.Boolean]::Parse('${{ needs.sdk.outputs.dry-run }}')
+          $NuGetApiKey = '${{ steps.nuget-login.outputs.NUGET_API_KEY }}'
+          $NugetPackages = @(Get-ChildItem -Path ./release-assets -Filter *.nupkg -File | Sort-Object Name)
+          if ($NugetPackages.Count -ne 1) {
+            throw "Expected exactly one SDK .nupkg in ./release-assets, found $($NugetPackages.Count)."
+          }
+
+          foreach ($NugetPackage in $NugetPackages) {
+            $PackagePath = Resolve-Path -LiteralPath $NugetPackage.FullName -Relative
+            Write-Host "Publishing $PackagePath to nuget.org"
+
+            if ($DryRun) {
+              Write-Host "Dry Run: skipping nuget.org publishing!"
+              continue
+            }
+
+            if ([string]::IsNullOrWhiteSpace($NuGetApiKey)) {
+              throw "NuGet/login did not provide a NuGet API key."
+            }
+
+            $PushArgs = @(
+              'nuget', 'push', $PackagePath,
+              '--api-key', $NuGetApiKey,
+              '--source', $Env:SDK_PACKAGE_SOURCE,
+              '--skip-duplicate', '--no-symbols'
+            )
+            & dotnet @PushArgs
+            if ($LASTEXITCODE -ne 0) {
+              throw "dotnet nuget push failed for $PackagePath with exit code $LASTEXITCODE"
+            }
+          }
+
+      - name: Create GitHub release
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: release-assets
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $DryRun = [System.Boolean]::Parse('${{ needs.sdk.outputs.dry-run }}')
+          $PackageVersion = '${{ needs.sdk.outputs.sdk-package-version }}'
+          $ReleaseTag = '${{ needs.sdk.outputs.release-tag }}'
+          $ReleaseTitle = '${{ needs.sdk.outputs.release-title }}'
+          $Repository = $Env:GITHUB_REPOSITORY
+          $SourceCommit = '${{ needs.sdk.outputs.powershell-source-commit }}'
+          $CodeSigned = '${{ needs.sdk.outputs.code-signed }}'
+
+          $NugetPackages = @(Get-ChildItem -Filter *.nupkg -File | Sort-Object Name)
+          if ($NugetPackages.Count -ne 1) {
+            throw "Expected exactly one SDK .nupkg in the release package directory, found $($NugetPackages.Count)."
+          }
+
+          $CliArchives = @(Get-ChildItem -File | Where-Object { $_.Name -like 'PowerShell-*.tar.gz' } | Sort-Object Name)
+          if ($CliArchives.Count -ne 6) {
+            throw "Expected exactly six PowerShell CLI archives in the release package directory, found $($CliArchives.Count)."
+          }
+
+          $ReleaseAssetFiles = @($NugetPackages) + @($CliArchives)
+          $ReleaseAssetFiles = @($ReleaseAssetFiles | Sort-Object Name)
+
+          $HashPath = 'checksums'
+          $ChecksumLines = foreach ($ReleaseAssetFile in $ReleaseAssetFiles) {
+            $Hash = Get-FileHash -Algorithm SHA256 -LiteralPath $ReleaseAssetFile.FullName
+            "$($Hash.Hash)  $($ReleaseAssetFile.Name)"
+          }
+          Set-Content -Path $HashPath -Value $ChecksumLines -Encoding ASCII
+
+          echo "::group::checksums"
+          Get-Content $HashPath
+          echo "::endgroup::"
+
+          $NotesPath = 'release-notes.md'
+          $ReleaseNotes = @(
+            "# $ReleaseTitle",
+            "",
+            "| Field | Value |",
+            "| --- | --- |",
+            "| Package ID | $Env:SDK_PACKAGE_ID |",
+            "| Package version | $PackageVersion |",
+            "| PowerShell upstream release | ${{ needs.sdk.outputs.powershell-release-tag }} |",
+            "| PowerShell downstream source ref | ${{ needs.sdk.outputs.powershell-source-ref }} |",
+            "| PowerShell source commit | $SourceCommit |",
+            "| Code signed | $CodeSigned |",
+            "| CLI archives | $($CliArchives.Count) |"
+          )
+          Set-Content -Path $NotesPath -Value $ReleaseNotes -Encoding utf8
+
+          if ($DryRun) {
+            Write-Host "Dry Run: skipping GitHub release!"
+          } else {
+            $ReleaseAssets = @($ReleaseAssetFiles | ForEach-Object { $_.Name }) + $HashPath
+            & gh release create $ReleaseTag --repo $Repository --target $Env:GITHUB_SHA --title $ReleaseTitle --notes-file $NotesPath @ReleaseAssets
+            if ($LASTEXITCODE -ne 0) {
+              throw "gh release create failed for $ReleaseTag with exit code $LASTEXITCODE"
+            }
+          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,5 @@
 name: PowerShell Release
 on:
-  push:
-    branches:
-      - refactor-release-workflows
-    paths:
-      - ".github/workflows/release.yml"
-      - ".github/workflows/powershell-sdk.yml"
-      - ".github/workflows/powershell-cli.yml"
   workflow_dispatch:
     inputs:
       sdk_package_revision:
@@ -54,11 +47,11 @@ jobs:
       actions: read
       contents: read
     with:
-      sdk_package_revision: ${{ github.event_name == 'workflow_dispatch' && inputs.sdk_package_revision || '' }}
-      github-env: ${{ github.event_name == 'workflow_dispatch' && inputs.github-env || 'auto' }}
-      skip-publish: ${{ github.event_name == 'workflow_dispatch' && inputs.skip-publish }}
-      dry-run: ${{ github.event_name != 'workflow_dispatch' || inputs.dry-run }}
-      sign-dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.sign-dry-run }}
+      sdk_package_revision: ${{ inputs.sdk_package_revision }}
+      github-env: ${{ inputs.github-env }}
+      skip-publish: ${{ inputs.skip-publish }}
+      dry-run: ${{ inputs.dry-run }}
+      sign-dry-run: ${{ inputs.sign-dry-run }}
     secrets: inherit
 
   cli:

--- a/README.md
+++ b/README.md
@@ -45,15 +45,16 @@ The local script writes under `output\local-sdk\<rid>\` and produces a single-RI
 
 | Workflow | Purpose | Output |
 | --- | --- | --- |
-| `.github/workflows/powershell-sdk.yml` | Builds PowerShell from source, vendors the source-built PowerShell SDK assemblies into one `Devolutions.PowerShell.SDK` package, signs the source-built payloads inside it for release, validates it in a sample .NET app with opt-in apphost import, and can publish the validated package. | `PowerShell-SDK-Release-7.6.3.0` artifact containing one `.nupkg`; optional NuGet.org publish plus GitHub release `v7.6.3.0`. |
-| `.github/workflows/powershell.yml` | Restores the pinned `Devolutions.PowerShell.SDK` package, imports its apphost and module payload through MSBuild, publishes a self-contained PowerShell layout, and repackages it for Windows, macOS, and Linux on x64 and arm64. | `PowerShell-7.6.3-<os>-<arch>` `.tar.gz` artifacts. |
+| `.github/workflows/powershell-sdk.yml` | Builds PowerShell from source, vendors the source-built PowerShell SDK assemblies into one `Devolutions.PowerShell.SDK` package, signs the source-built payloads, and validates it in a sample .NET app with opt-in apphost import. It can run manually or as a reusable workflow. | `PowerShell-SDK-Release-7.6.3.0` artifact containing one `.nupkg`. |
+| `.github/workflows/powershell-cli.yml` | Restores a pinned or workflow-built `Devolutions.PowerShell.SDK` package, imports its apphost and module payload through MSBuild, publishes a self-contained PowerShell layout, and repackages it for Windows, macOS, and Linux on x64 and arm64. It can run manually or as a reusable workflow. | `PowerShell-7.6.3-<os>-<arch>` `.tar.gz` artifacts. |
+| `.github/workflows/release.yml` | Orchestrates the reusable SDK workflow first, repackages that signed SDK artifact through the reusable CLI workflow, publishes the SDK package, and creates the GitHub release. | NuGet.org publish plus GitHub release `v7.6.3.0` containing the SDK `.nupkg`, all CLI `.tar.gz` archives, and checksums. |
 | `.github/workflows/dotnet-runtime.yml` | Builds the .NET runtime tag used by this PowerShell release for Windows, macOS, and Linux on x86_64 and arm64 with prebuilt clang+llvm from `awakecoding/llvm-prebuilt`. | Runtime build output in the workflow logs/workspace. |
 
 All workflows are manual and can be started from the GitHub Actions **Run workflow** button.
 
-## Publishing the PowerShell SDK package
+## Publishing PowerShell releases
 
-The SDK workflow publishes only after the package has been built, had its source-built payloads signed for release, and been validated on every RID in the validation matrix. The release version is `POWERSHELL_VERSION.SDK_PACKAGE_REVISION`, such as `7.6.3.0`.
+The release workflow publishes only after the SDK package has been built, had its source-built payloads signed for release, been validated on every RID in the validation matrix, and been repackaged into every CLI archive. The release version is `POWERSHELL_VERSION.SDK_PACKAGE_REVISION`, such as `7.6.3.0`.
 
 Manual inputs:
 
@@ -61,11 +62,11 @@ Manual inputs:
 | --- | --- |
 | `sdk_package_revision` | Optional revision override. Leave blank to use the explicit `SDK_PACKAGE_REVISION` env pin, set a number such as `1` for a specific downstream revision, or set `auto` to infer the next revision from existing `vX.Y.Z.R` release tags. |
 | `github-env` | `auto`, `test`, or `prod`. `auto` selects `publish-prod` for manual runs from `master` and `publish-test` elsewhere. |
-| `skip-publish` | Builds and validates the package without publishing to NuGet.org or creating a GitHub release. |
+| `skip-publish` | Builds, signs when requested, validates, and packages artifacts without publishing to NuGet.org or creating a GitHub release. |
 | `dry-run` | Simulates publishing. This defaults to `true`; non-production environments are forced to dry-run when publishing is requested. |
 | `sign-dry-run` | Signs the package during a dry-run when code signing secrets are available. This defaults to `false` so dry-runs can exercise packaging and release flow without requiring signing credentials. |
 
-Before validation and publishing, the SDK workflow runs a signing stage that downloads the built `.nupkg`, installs the latest `Devolutions/psign` `psign-tool-linux-x64.zip`, extracts the package, signs the source-built payloads inside it with Azure Key Vault, and repacks the `.nupkg` without adding a NuGet package signature. The signing pass covers the built PowerShell assemblies in `ref/` and `runtimes/*/lib/`, the apphost payloads in `tools/apphost/*` and `runtimes/*/native`, the Windows desktop payload, and the built-in module manifests/format/script files in `contentFiles/any/any/runtimes/**/Modules/**`. A non-dry-run publish requires these environment secrets and variables:
+Before validation and CLI packaging, the SDK workflow runs a signing stage that downloads the built `.nupkg`, installs the latest `Devolutions/psign` `psign-tool-linux-x64.zip`, extracts the package, signs the source-built payloads inside it with Azure Key Vault, and repacks the `.nupkg` without adding a NuGet package signature. The signing pass covers the built PowerShell assemblies in `ref/` and `runtimes/*/lib/`, the apphost payloads in `tools/apphost/*` and `runtimes/*/native`, the Windows desktop payload, and the built-in module manifests/format/script files in `contentFiles/any/any/runtimes/**/Modules/**`. CLI archives are built from this release-ready SDK package, so their Windows executable and module payloads come from the signed `.nupkg`. A non-dry-run publish requires these environment secrets and variables:
 
 | Name | Type |
 | --- | --- |
@@ -76,7 +77,7 @@ Before validation and publishing, the SDK workflow runs a signing stage that dow
 | `CODE_SIGNING_CERTIFICATE_NAME` | Secret |
 | `CODE_SIGNING_TIMESTAMP_SERVER` | Variable |
 
-Publishing uses the same NuGet.org OIDC pattern as `Devolutions/gsudo-distro`: repository environments named `publish-test` and `publish-prod`, `NuGet/login@v1`, and a `NUGET_BOT_USERNAME` secret available to the publishing environment. The workflow grants `id-token: write` for NuGet OIDC and `contents: write` for GitHub release creation. A real publish pushes the validated `.nupkg` containing signed Windows payloads to `https://api.nuget.org/v3/index.json` and creates a GitHub release named `Devolutions.PowerShell.SDK vX.Y.Z.R` with tag `vX.Y.Z.R`, release notes, the package asset, and a SHA256 checksum file.
+Publishing uses the same NuGet.org OIDC pattern as `Devolutions/gsudo-distro`: repository environments named `publish-test` and `publish-prod`, `NuGet/login@v1`, and a `NUGET_BOT_USERNAME` secret available to the publishing environment. The release workflow grants `id-token: write` for NuGet OIDC and `contents: write` for GitHub release creation only in the publishing job. A real publish pushes the validated `.nupkg` containing signed Windows payloads to `https://api.nuget.org/v3/index.json` and creates a GitHub release named `Devolutions.PowerShell.SDK vX.Y.Z.R` with tag `vX.Y.Z.R`, release notes, the SDK package asset, every CLI archive, and a SHA256 checksum file covering all release assets.
 
 ## Branching model
 
@@ -86,7 +87,7 @@ This repository follows a downstream patch branch model inspired by `Devolutions
 
 When moving to a new upstream PowerShell release, the bump touches four surfaces in the same PR:
 
-1. Workflow `env` blocks in `.github/workflows/powershell-sdk.yml` and `.github/workflows/powershell.yml`: `POWERSHELL_VERSION`, `POWERSHELL_RELEASE_TAG`, `POWERSHELL_UPSTREAM_TAG`, and `POWERSHELL_SOURCE_REF`. Reset `.github/workflows/powershell-sdk.yml` `SDK_PACKAGE_REVISION` to `0` for the first downstream SDK package built from a new upstream tag, and keep `.github/workflows/powershell.yml` `SDK_PACKAGE_VERSION` and `SDK_PACKAGE_REVISION` aligned with the SDK package version that the distro workflow should repackage.
+1. Workflow `env` blocks in `.github/workflows/powershell-sdk.yml` and `.github/workflows/powershell-cli.yml`: `POWERSHELL_VERSION`, `POWERSHELL_RELEASE_TAG`, `POWERSHELL_UPSTREAM_TAG`, and `POWERSHELL_SOURCE_REF`. Reset `.github/workflows/powershell-sdk.yml` `SDK_PACKAGE_REVISION` to `0` for the first downstream SDK package built from a new upstream tag, and keep `.github/workflows/powershell-cli.yml` `SDK_PACKAGE_VERSION` and `SDK_PACKAGE_REVISION` aligned with the SDK package version that the CLI workflow should repackage by default.
 2. `.gitmodules`: the `branch = downstream/vX.Y.Z` line under `[submodule "pwsh-src"]` (git does not expand variables in `.gitmodules`, so this must be edited literally).
 3. The `pwsh-src` submodule pointer on `master`, bumped to the new `downstream/vX.Y.Z` tip with `git submodule update --remote pwsh-src && git add pwsh-src`.
 4. The "Current pins" table above.
@@ -148,7 +149,7 @@ The SDK package also stages the optional PSGallery modules that upstream PowerSh
 
 Set `PowerShellSDKPSGalleryModuleNames` to a semicolon-delimited subset such as `Microsoft.PowerShell.Archive;Microsoft.PowerShell.ThreadJob` when a consumer does not need every staged PSGallery module. Set `PowerShellSDKPSGalleryModulesCopyToOutput` or `PowerShellSDKPSGalleryModulesCopyToPublish` to `false` to disable one copy phase. PSGallery modules increase package and output size, include additional package-management or interactive functionality, and several are script modules subject to the bundled PowerShell execution policy, so consumers should enable them deliberately.
 
-The secondary PowerShell distro workflow uses this same package-consumer path instead of rebuilding PowerShell from source. It creates a temporary .NET project, restores the pinned SDK package from the pinned package source, enables root apphost and PSGallery module import, opts into localized resources when present, publishes self-contained for the matrix RID, removes the temporary host application files, validates the PowerShell layout, and archives the result as `.tar.gz` for every platform, including Windows. Windows archives additionally stage the matching `Microsoft.WindowsDesktop.App.Runtime.<rid>` payload so WPF/WinForms assemblies such as `PresentationFramework.dll`, `System.Windows.Forms.dll`, and `WindowsBase.dll` load from `$PSHOME`. For end-to-end dry runs, pass `sdk_artifact_run_id` to `.github/workflows/powershell.yml` so it downloads the `PowerShell-SDK-Release-X.Y.Z.R` artifact from a prior `.github/workflows/powershell-sdk.yml` run and repackages that workflow-built `.nupkg` instead of restoring from NuGet.org.
+The secondary PowerShell CLI workflow uses this same package-consumer path instead of rebuilding PowerShell from source. It creates a temporary .NET project, restores the pinned SDK package from the pinned package source or a workflow-built SDK artifact, enables root apphost and PSGallery module import, opts into localized resources when present, publishes self-contained for the matrix RID, removes the temporary host application files, validates the PowerShell layout, and archives the result as `.tar.gz` for every platform, including Windows. Windows archives additionally stage the matching `Microsoft.WindowsDesktop.App.Runtime.<rid>` payload so WPF/WinForms assemblies such as `PresentationFramework.dll`, `System.Windows.Forms.dll`, and `WindowsBase.dll` load from `$PSHOME`. For end-to-end dry runs outside `.github/workflows/release.yml`, pass `sdk_artifact_run_id` to `.github/workflows/powershell-cli.yml` so it downloads the `PowerShell-SDK-Release-X.Y.Z.R` artifact from a prior `.github/workflows/powershell-sdk.yml` run and repackages that workflow-built `.nupkg` instead of restoring from NuGet.org. If the artifact name does not include the SDK version, also pass `sdk_package_version`.
 
 During NuGet packing, upstream `Microsoft.PowerShell.SDK` content file/reference metadata can emit NU5100/NU5131 package analysis warnings. The SDK workflow treats package validation as the source of truth: the generated sample must restore only the vendored PowerShell package ID, build, publish framework-dependent and self-contained outputs, execute `pwsh`, and load copied built-in modules.
 


### PR DESCRIPTION
## Summary

- Split the PowerShell workflows into reusable SDK build/sign/validate, CLI packaging, and a dedicated release orchestrator.
- Rename the distro packaging workflow to `powershell-cli.yml` and have `release.yml` attach both SDK and CLI artifacts to one GitHub release.
- Keep release publishing controls (`github-env`, `skip-publish`, `dry-run`, `sign-dry-run`) and make `release.yml` the only NuGet/GitHub release publisher.
- Patch the ephemeral Windows apphost shim project during SDK apphost builds to avoid pre-existing WindowsDesktop SDK annotations.

## Validation

- Parsed workflow YAML locally and ran `git diff --check`.
- Ran dry-run release workflow successfully: https://github.com/Devolutions/pwsh-distro/actions/runs/28663043842
- Re-ran after the Windows apphost warning fix successfully: https://github.com/Devolutions/pwsh-distro/actions/runs/28664350869