### PR TITLE
Simplify PowerShell SDK targets options

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,50 +107,54 @@ The vendored SDK keeps upstream PowerShell build/runtime metadata separate from 
 
 The package keeps original assembly identities (`System.Management.Automation.dll`, `Microsoft.PowerShell.Commands.Utility.dll`, and related assemblies) so consumers only need to change the NuGet package reference. Source-built PowerShell assemblies are discovered from the current `pwsh-src` build outputs and embedded directly in `Devolutions.PowerShell.SDK`; the package records the embedded Microsoft package IDs and source-built package asset paths under `buildTransitive`, and validation fails if any of those package IDs appear in the restore graph. External packages that are not built by this repository, including `Microsoft.PowerShell.Native` and `Microsoft.PowerShell.MarkdownRender`, remain normal public NuGet dependencies.
 
-The SDK package also includes apphost files for `win-x64`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-x64`, and `osx-arm64`. The root apphost mode uses the native `pwsh`/`pwsh.exe` launcher staged from the public `Devolutions.MultiPwsh.Cli` build-time package on NuGet.org; `pwsh.dll`, `pwsh.runtimeconfig.json`, runtime assemblies, and modules remain source-built by this repository. These files are inert by default. A consuming project can copy the matching `pwsh`/`pwsh.exe`, `pwsh.dll`, `pwsh.runtimeconfig.json`, and the matching built-in module manifests into its output by setting:
+The SDK package also includes apphost files for `win-x64`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-x64`, and `osx-arm64`. These files are inert by default. A consuming project opts in by choosing an apphost layout. The root layout copies `pwsh`/`pwsh.exe`, `pwsh.dll`, `pwsh.runtimeconfig.json`, runtime assemblies, and built-in module manifests to the app root:
 
 ```xml
 <PropertyGroup>
-  <PowerShellSDKIncludeAppHost>true</PowerShellSDKIncludeAppHost>
+  <PowerShellSDKAppHostLayout>Root</PowerShellSDKAppHostLayout>
 </PropertyGroup>
 ```
 
-The package selects `$(RuntimeIdentifier)` first, then falls back to the SDK host runtime identifier. Set `PowerShellSDKAppHostRuntimeIdentifier` to override that selection explicitly. Unsupported runtime identifiers fail the build with a clear error instead of silently omitting apphost files. The apphost output is intended for running scripts with the core built-in modules from `$PSHOME/Modules`; it is not a full PowerShell distribution archive unless consumers deliberately enable the optional payloads below.
-
-For applications that need architecture-specific apphost launchers in a native asset layout, opt in to runtime-native apphost output:
+Applications that need architecture-specific apphost launchers in a native asset layout can use the runtime-native layout:
 
 ```xml
 <PropertyGroup>
-  <PowerShellSDKIncludeRuntimeNativeAppHosts>true</PowerShellSDKIncludeRuntimeNativeAppHosts>
+  <PowerShellSDKAppHostLayout>RuntimeNative</PowerShellSDKAppHostLayout>
   <PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers>win-x64;win-arm64</PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers>
 </PropertyGroup>
 ```
 
-This copies a minimal native launcher to `runtimes/<rid>/native/pwsh.exe` (or `pwsh` on Unix) for each selected RID. The launcher is patched to load `../../../pwsh.dll`, so `pwsh.dll`, `pwsh.runtimeconfig.json`, PowerShell runtime assemblies, built-in modules, and required RID-specific runtime library dependencies are copied once to the app output root and shared with the consuming executable. Leave `PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers` empty to copy every runtime-native launcher included in the package, or set it to a semicolon-delimited RID list. Set `PowerShellSDKRuntimeNativeSharedPayloadRuntimeIdentifier` to override the app-root payload RID; otherwise it follows `$(RuntimeIdentifier)`, `$(NETCoreSdkRuntimeIdentifier)`, or the root apphost override. Shared payload lookup normalizes platform-specific TFMs such as `net10.0-windows10.0.19041` to the package TFM `net10.0`; set `PowerShellSDKRuntimeNativeSharedPayloadTargetFramework` only if an explicit package payload TFM override is needed. Set `PowerShellSDKRuntimeNativeAppHostCopyToOutput` or `PowerShellSDKRuntimeNativeAppHostCopyToPublish` to `false` to disable one copy phase.
+This copies a minimal native launcher to `runtimes/<rid>/native/pwsh.exe` (or `pwsh` on Unix) for each selected RID. The launcher loads `../../../pwsh.dll`, so `pwsh.dll`, `pwsh.runtimeconfig.json`, PowerShell runtime assemblies, built-in modules, and required RID-specific runtime library dependencies are copied once to the app output root and shared with the consuming executable. Leave `PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers` empty to copy every runtime-native launcher included in the package, or set it to a semicolon-delimited RID list. Unknown RIDs fail the build.
 
 The source-built PowerShell runtime is patched so out-of-process jobs can use the selected runtime-native launcher when `$PSHOME/pwsh.exe` is not present. This lets `Start-Job` work in bundled-host scenarios that copy `pwsh.exe` under `runtimes/<rid>/native` instead of the app root.
 
-When either apphost mode is enabled, the package also generates `powershell.config.json` beside `pwsh.dll` and `pwsh.runtimeconfig.json` in the app or publish root. The default config sets `Microsoft.PowerShell:ExecutionPolicy` to `Bypass`, which lets bundled script modules load from the app-root `$PSHOME` without requiring every launcher invocation to pass `-ExecutionPolicy Bypass`. Set `PowerShellSDKConfigExecutionPolicy` to use another policy value. Set `PowerShellSDKGenerateConfig`, `PowerShellSDKConfigCopyToOutput`, or `PowerShellSDKConfigCopyToPublish` to `false` to disable generation or one copy phase. Existing `powershell.config.json` files are preserved by default; set `PowerShellSDKConfigOverwriteExisting` to `true` only when the package-generated config should replace an existing file.
-
-Localized resource assemblies are staged in the SDK package but are inert by default to keep normal SDK consumers lean. To copy the staged culture directories beside the apphost payload, opt in explicitly:
+Use `PowerShellSDKCopyPhases` to decide where opted-in payloads are copied. The default is `Output;Publish`; set it to `Output` or `Publish` to disable the other phase. The package also has optional config, localized resource, and PSGallery module payloads:
 
 ```xml
 <PropertyGroup>
-  <PowerShellSDKIncludeLocalizedResources>true</PowerShellSDKIncludeLocalizedResources>
+  <PowerShellSDKLocalizedResources>Copy</PowerShellSDKLocalizedResources>
+  <PowerShellSDKPSGalleryModules>Microsoft.PowerShell.Archive;Microsoft.PowerShell.ThreadJob</PowerShellSDKPSGalleryModules>
 </PropertyGroup>
 ```
 
-Set `PowerShellSDKLocalizedResourcesCopyToOutput` or `PowerShellSDKLocalizedResourcesCopyToPublish` to `false` to disable one copy phase. The PowerShell distro archive workflow opts in when the restored SDK package contains localized resources.
+| Property | Default | Values | Effect |
+| --- | --- | --- | --- |
+| `PowerShellSDKAppHostLayout` | `None` | `None`, `Root`, `RuntimeNative`, `Both` | Selects the apphost file layout. |
+| `PowerShellSDKAppHostImplementation` | `Auto` | `Auto`, `MultiPwsh`, `DotNet` | Selects the apphost executable implementation when the requested layout/package assets support it. Current package assets support `MultiPwsh` for `Root` and `DotNet` for `RuntimeNative`. |
+| `PowerShellSDKAppHostRuntimeIdentifier` | empty | RID | Overrides root apphost RID selection; otherwise `$(RuntimeIdentifier)` then `$(NETCoreSdkRuntimeIdentifier)` are used. |
+| `PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers` | empty | RID list | Semicolon-delimited runtime-native launcher RIDs; empty selects all packaged RIDs. |
+| `PowerShellSDKRuntimeNativeSharedPayloadRuntimeIdentifier` | empty | RID | Overrides the shared app-root PowerShell payload RID. Otherwise it follows `$(RuntimeIdentifier)`, `$(NETCoreSdkRuntimeIdentifier)`, then `PowerShellSDKAppHostRuntimeIdentifier`. |
+| `PowerShellSDKRuntimeNativeSharedPayloadTargetFramework` | empty | TFM | Overrides shared payload TFM lookup; normally platform-specific TFMs such as `net10.0-windows10.0.19041` normalize to the package TFM `net10.0`. |
+| `PowerShellSDKCopyPhases` | `Output;Publish` | `Output`, `Publish`, `Output;Publish` | Controls build output and publish copying for opted-in payloads. |
+| `PowerShellSDKConfig` | `Copy` | `None`, `Copy` | Generates `powershell.config.json` when an apphost layout is enabled. |
+| `PowerShellSDKConfigExecutionPolicy` | `Bypass` | PowerShell execution policy | Sets `Microsoft.PowerShell:ExecutionPolicy` in generated config. |
+| `PowerShellSDKConfigOverwriteExisting` | `false` | `true`, `false` | Replaces existing `powershell.config.json` only when `true`. |
+| `PowerShellSDKLocalizedResources` | `None` | `None`, `Copy` | Copies staged localized resource assemblies beside the apphost payload. |
+| `PowerShellSDKPSGalleryModules` | `None` | `None`, `All`, or module list | Copies all staged PSGallery modules or a semicolon-delimited subset to `Modules`. |
 
-The SDK package also stages the optional PSGallery modules that upstream PowerShell bundles into full distribution archives. They are separate from the core built-in module payload and are inert by default. To copy all staged PSGallery modules to the app or publish root `Modules` directory, opt in explicitly:
+When passing semicolon-delimited values on the `dotnet` or `msbuild` command line, encode semicolons as `%3B`, such as `/p:PowerShellSDKCopyPhases=Output%3BPublish`.
 
-```xml
-<PropertyGroup>
-  <PowerShellSDKIncludePSGalleryModules>true</PowerShellSDKIncludePSGalleryModules>
-</PropertyGroup>
-```
-
-Set `PowerShellSDKPSGalleryModuleNames` to a semicolon-delimited subset such as `Microsoft.PowerShell.Archive;Microsoft.PowerShell.ThreadJob` when a consumer does not need every staged PSGallery module. Set `PowerShellSDKPSGalleryModulesCopyToOutput` or `PowerShellSDKPSGalleryModulesCopyToPublish` to `false` to disable one copy phase. PSGallery modules increase package and output size, include additional package-management or interactive functionality, and several are script modules subject to the bundled PowerShell execution policy, so consumers should enable them deliberately.
+The apphost output is intended for running scripts with the core built-in modules from `$PSHOME/Modules`; it is not a full PowerShell distribution archive unless consumers deliberately enable optional payloads such as localized resources and PSGallery modules. PSGallery modules increase package and output size, include additional package-management or interactive functionality, and several are script modules subject to the bundled PowerShell execution policy.
 
 The secondary PowerShell CLI workflow uses this same package-consumer path instead of rebuilding PowerShell from source. It creates a temporary .NET project, restores the pinned SDK package from the pinned package source or a workflow-built SDK artifact, enables root apphost and PSGallery module import, opts into localized resources when present, publishes self-contained for the matrix RID, removes the temporary host application files, validates the PowerShell layout, and archives the result as `.tar.gz` for every platform, including Windows. Windows archives additionally stage the matching `Microsoft.WindowsDesktop.App.Runtime.<rid>` payload so WPF/WinForms assemblies such as `PresentationFramework.dll`, `System.Windows.Forms.dll`, and `WindowsBase.dll` load from `$PSHOME`. For end-to-end dry runs outside `.github/workflows/release.yml`, pass `sdk_artifact_run_id` to `.github/workflows/powershell-cli.yml` so it downloads the `PowerShell-SDK-Release-X.Y.Z.R` artifact from a prior `.github/workflows/powershell-sdk.yml` run and repackages that workflow-built `.nupkg` instead of restoring from NuGet.org. If the artifact name does not include the SDK version, also pass `sdk_package_version`.
 

--- a/eng/Microsoft.PowerShell.SDK.targets
+++ b/eng/Microsoft.PowerShell.SDK.targets
@@ -131,32 +131,66 @@
   </UsingTask>
 
   <PropertyGroup>
-    <PowerShellSDKIncludeAppHost Condition="'$(PowerShellSDKIncludeAppHost)' == ''">false</PowerShellSDKIncludeAppHost>
-    <PowerShellSDKIncludeRuntimeNativeAppHosts Condition="'$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == ''">false</PowerShellSDKIncludeRuntimeNativeAppHosts>
-    <PowerShellSDKRuntimeNativeAppHostCopyToOutput Condition="'$(PowerShellSDKRuntimeNativeAppHostCopyToOutput)' == ''">true</PowerShellSDKRuntimeNativeAppHostCopyToOutput>
-    <PowerShellSDKRuntimeNativeAppHostCopyToPublish Condition="'$(PowerShellSDKRuntimeNativeAppHostCopyToPublish)' == ''">true</PowerShellSDKRuntimeNativeAppHostCopyToPublish>
-    <PowerShellSDKIncludePSGalleryModules Condition="'$(PowerShellSDKIncludePSGalleryModules)' == ''">false</PowerShellSDKIncludePSGalleryModules>
-    <PowerShellSDKPSGalleryModulesCopyToOutput Condition="'$(PowerShellSDKPSGalleryModulesCopyToOutput)' == ''">true</PowerShellSDKPSGalleryModulesCopyToOutput>
-    <PowerShellSDKPSGalleryModulesCopyToPublish Condition="'$(PowerShellSDKPSGalleryModulesCopyToPublish)' == ''">true</PowerShellSDKPSGalleryModulesCopyToPublish>
-    <PowerShellSDKGenerateConfig Condition="'$(PowerShellSDKGenerateConfig)' == ''">true</PowerShellSDKGenerateConfig>
+    <PowerShellSDKAppHostLayout Condition="'$(PowerShellSDKAppHostLayout)' == ''">None</PowerShellSDKAppHostLayout>
+    <PowerShellSDKAppHostImplementation Condition="'$(PowerShellSDKAppHostImplementation)' == ''">Auto</PowerShellSDKAppHostImplementation>
+    <PowerShellSDKCopyPhases Condition="'$(PowerShellSDKCopyPhases)' == ''">Output;Publish</PowerShellSDKCopyPhases>
+    <PowerShellSDKConfig Condition="'$(PowerShellSDKConfig)' == ''">Copy</PowerShellSDKConfig>
     <PowerShellSDKConfigExecutionPolicy Condition="'$(PowerShellSDKConfigExecutionPolicy)' == ''">Bypass</PowerShellSDKConfigExecutionPolicy>
-    <PowerShellSDKConfigCopyToOutput Condition="'$(PowerShellSDKConfigCopyToOutput)' == ''">true</PowerShellSDKConfigCopyToOutput>
-    <PowerShellSDKConfigCopyToPublish Condition="'$(PowerShellSDKConfigCopyToPublish)' == ''">true</PowerShellSDKConfigCopyToPublish>
     <PowerShellSDKConfigOverwriteExisting Condition="'$(PowerShellSDKConfigOverwriteExisting)' == ''">false</PowerShellSDKConfigOverwriteExisting>
-    <PowerShellSDKIncludeLocalizedResources Condition="'$(PowerShellSDKIncludeLocalizedResources)' == ''">false</PowerShellSDKIncludeLocalizedResources>
-    <PowerShellSDKLocalizedResourcesCopyToOutput Condition="'$(PowerShellSDKLocalizedResourcesCopyToOutput)' == ''">true</PowerShellSDKLocalizedResourcesCopyToOutput>
-    <PowerShellSDKLocalizedResourcesCopyToPublish Condition="'$(PowerShellSDKLocalizedResourcesCopyToPublish)' == ''">true</PowerShellSDKLocalizedResourcesCopyToPublish>
-    <_PowerShellSDKRuntimeNativeCopyToOutputEnabled Condition="('$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'true' or '$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'True') and ('$(PowerShellSDKRuntimeNativeAppHostCopyToOutput)' == 'true' or '$(PowerShellSDKRuntimeNativeAppHostCopyToOutput)' == 'True')">true</_PowerShellSDKRuntimeNativeCopyToOutputEnabled>
-    <_PowerShellSDKRuntimeNativeCopyToPublishEnabled Condition="('$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'true' or '$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'True') and ('$(PowerShellSDKRuntimeNativeAppHostCopyToPublish)' == 'true' or '$(PowerShellSDKRuntimeNativeAppHostCopyToPublish)' == 'True')">true</_PowerShellSDKRuntimeNativeCopyToPublishEnabled>
-    <_PowerShellSDKPSGalleryModulesCopyToOutputEnabled Condition="('$(PowerShellSDKIncludePSGalleryModules)' == 'true' or '$(PowerShellSDKIncludePSGalleryModules)' == 'True') and ('$(PowerShellSDKPSGalleryModulesCopyToOutput)' == 'true' or '$(PowerShellSDKPSGalleryModulesCopyToOutput)' == 'True')">true</_PowerShellSDKPSGalleryModulesCopyToOutputEnabled>
-    <_PowerShellSDKPSGalleryModulesCopyToPublishEnabled Condition="('$(PowerShellSDKIncludePSGalleryModules)' == 'true' or '$(PowerShellSDKIncludePSGalleryModules)' == 'True') and ('$(PowerShellSDKPSGalleryModulesCopyToPublish)' == 'true' or '$(PowerShellSDKPSGalleryModulesCopyToPublish)' == 'True')">true</_PowerShellSDKPSGalleryModulesCopyToPublishEnabled>
-    <_PowerShellSDKLocalizedResourcesCopyToOutputEnabled Condition="('$(PowerShellSDKIncludeLocalizedResources)' == 'true' or '$(PowerShellSDKIncludeLocalizedResources)' == 'True') and ('$(PowerShellSDKLocalizedResourcesCopyToOutput)' == 'true' or '$(PowerShellSDKLocalizedResourcesCopyToOutput)' == 'True')">true</_PowerShellSDKLocalizedResourcesCopyToOutputEnabled>
-    <_PowerShellSDKLocalizedResourcesCopyToPublishEnabled Condition="('$(PowerShellSDKIncludeLocalizedResources)' == 'true' or '$(PowerShellSDKIncludeLocalizedResources)' == 'True') and ('$(PowerShellSDKLocalizedResourcesCopyToPublish)' == 'true' or '$(PowerShellSDKLocalizedResourcesCopyToPublish)' == 'True')">true</_PowerShellSDKLocalizedResourcesCopyToPublishEnabled>
-    <_PowerShellSDKConfigEnabled Condition="('$(PowerShellSDKGenerateConfig)' == 'true' or '$(PowerShellSDKGenerateConfig)' == 'True') and (('$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True') or ('$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'true' or '$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'True'))">true</_PowerShellSDKConfigEnabled>
-    <_PowerShellSDKConfigCopyToOutputEnabled Condition="'$(_PowerShellSDKConfigEnabled)' == 'true' and ('$(PowerShellSDKConfigCopyToOutput)' == 'true' or '$(PowerShellSDKConfigCopyToOutput)' == 'True')">true</_PowerShellSDKConfigCopyToOutputEnabled>
-    <_PowerShellSDKConfigCopyToPublishEnabled Condition="'$(_PowerShellSDKConfigEnabled)' == 'true' and ('$(PowerShellSDKConfigCopyToPublish)' == 'true' or '$(PowerShellSDKConfigCopyToPublish)' == 'True')">true</_PowerShellSDKConfigCopyToPublishEnabled>
+    <PowerShellSDKLocalizedResources Condition="'$(PowerShellSDKLocalizedResources)' == ''">None</PowerShellSDKLocalizedResources>
+    <PowerShellSDKPSGalleryModules Condition="'$(PowerShellSDKPSGalleryModules)' == ''">None</PowerShellSDKPSGalleryModules>
+
+    <_PowerShellSDKAppHostLayoutValue>$([System.String]::Copy('$(PowerShellSDKAppHostLayout)').ToLowerInvariant())</_PowerShellSDKAppHostLayoutValue>
+    <_PowerShellSDKAppHostImplementationValue>$([System.String]::Copy('$(PowerShellSDKAppHostImplementation)').ToLowerInvariant())</_PowerShellSDKAppHostImplementationValue>
+    <_PowerShellSDKConfigValue>$([System.String]::Copy('$(PowerShellSDKConfig)').ToLowerInvariant())</_PowerShellSDKConfigValue>
+    <_PowerShellSDKConfigOverwriteExistingValue>$([System.String]::Copy('$(PowerShellSDKConfigOverwriteExisting)').ToLowerInvariant())</_PowerShellSDKConfigOverwriteExistingValue>
+    <_PowerShellSDKLocalizedResourcesValue>$([System.String]::Copy('$(PowerShellSDKLocalizedResources)').ToLowerInvariant())</_PowerShellSDKLocalizedResourcesValue>
+    <_PowerShellSDKPSGalleryModulesValue>$([System.String]::Copy('$(PowerShellSDKPSGalleryModules)').ToLowerInvariant())</_PowerShellSDKPSGalleryModulesValue>
+    <_PowerShellSDKSelfContainedValue>$([System.String]::Copy('$(SelfContained)').ToLowerInvariant())</_PowerShellSDKSelfContainedValue>
+    <_PowerShellSDKCopyPhasesForItems>$([System.Text.RegularExpressions.Regex]::Replace('$(PowerShellSDKCopyPhases)', '%3[Bb]', ';'))</_PowerShellSDKCopyPhasesForItems>
+    <_PowerShellSDKRootAppHostEnabled Condition="'$(_PowerShellSDKAppHostLayoutValue)' == 'root' or '$(_PowerShellSDKAppHostLayoutValue)' == 'both'">true</_PowerShellSDKRootAppHostEnabled>
+    <_PowerShellSDKRuntimeNativeAppHostEnabled Condition="'$(_PowerShellSDKAppHostLayoutValue)' == 'runtimenative' or '$(_PowerShellSDKAppHostLayoutValue)' == 'both'">true</_PowerShellSDKRuntimeNativeAppHostEnabled>
+    <_PowerShellSDKAppHostEnabled Condition="'$(_PowerShellSDKRootAppHostEnabled)' == 'true' or '$(_PowerShellSDKRuntimeNativeAppHostEnabled)' == 'true'">true</_PowerShellSDKAppHostEnabled>
+    <_PowerShellSDKCopyToOutputEnabled Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(_PowerShellSDKCopyPhasesForItems)', '(^|;)(?i:Output)(;|$)')) == 'True'">true</_PowerShellSDKCopyToOutputEnabled>
+    <_PowerShellSDKCopyToPublishEnabled Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(_PowerShellSDKCopyPhasesForItems)', '(^|;)(?i:Publish)(;|$)')) == 'True'">true</_PowerShellSDKCopyToPublishEnabled>
+    <_PowerShellSDKRootCopyToOutputEnabled Condition="'$(_PowerShellSDKRootAppHostEnabled)' == 'true' and '$(_PowerShellSDKCopyToOutputEnabled)' == 'true'">true</_PowerShellSDKRootCopyToOutputEnabled>
+    <_PowerShellSDKRootCopyToPublishEnabled Condition="'$(_PowerShellSDKRootAppHostEnabled)' == 'true' and '$(_PowerShellSDKCopyToPublishEnabled)' == 'true'">true</_PowerShellSDKRootCopyToPublishEnabled>
+    <_PowerShellSDKRuntimeNativeCopyToOutputEnabled Condition="'$(_PowerShellSDKRuntimeNativeAppHostEnabled)' == 'true' and '$(_PowerShellSDKCopyToOutputEnabled)' == 'true'">true</_PowerShellSDKRuntimeNativeCopyToOutputEnabled>
+    <_PowerShellSDKRuntimeNativeCopyToPublishEnabled Condition="'$(_PowerShellSDKRuntimeNativeAppHostEnabled)' == 'true' and '$(_PowerShellSDKCopyToPublishEnabled)' == 'true'">true</_PowerShellSDKRuntimeNativeCopyToPublishEnabled>
+    <_PowerShellSDKPSGalleryModulesEnabled Condition="'$(PowerShellSDKPSGalleryModules)' != '' and '$(_PowerShellSDKPSGalleryModulesValue)' != 'none'">true</_PowerShellSDKPSGalleryModulesEnabled>
+    <_PowerShellSDKPSGalleryModulesCopyToOutputEnabled Condition="'$(_PowerShellSDKPSGalleryModulesEnabled)' == 'true' and '$(_PowerShellSDKCopyToOutputEnabled)' == 'true'">true</_PowerShellSDKPSGalleryModulesCopyToOutputEnabled>
+    <_PowerShellSDKPSGalleryModulesCopyToPublishEnabled Condition="'$(_PowerShellSDKPSGalleryModulesEnabled)' == 'true' and '$(_PowerShellSDKCopyToPublishEnabled)' == 'true'">true</_PowerShellSDKPSGalleryModulesCopyToPublishEnabled>
+    <_PowerShellSDKLocalizedResourcesEnabled Condition="'$(_PowerShellSDKLocalizedResourcesValue)' == 'copy'">true</_PowerShellSDKLocalizedResourcesEnabled>
+    <_PowerShellSDKLocalizedResourcesCopyToOutputEnabled Condition="'$(_PowerShellSDKLocalizedResourcesEnabled)' == 'true' and '$(_PowerShellSDKCopyToOutputEnabled)' == 'true'">true</_PowerShellSDKLocalizedResourcesCopyToOutputEnabled>
+    <_PowerShellSDKLocalizedResourcesCopyToPublishEnabled Condition="'$(_PowerShellSDKLocalizedResourcesEnabled)' == 'true' and '$(_PowerShellSDKCopyToPublishEnabled)' == 'true'">true</_PowerShellSDKLocalizedResourcesCopyToPublishEnabled>
+    <_PowerShellSDKConfigEnabled Condition="'$(_PowerShellSDKConfigValue)' == 'copy' and '$(_PowerShellSDKAppHostEnabled)' == 'true'">true</_PowerShellSDKConfigEnabled>
+    <_PowerShellSDKConfigCopyToOutputEnabled Condition="'$(_PowerShellSDKConfigEnabled)' == 'true' and '$(_PowerShellSDKCopyToOutputEnabled)' == 'true'">true</_PowerShellSDKConfigCopyToOutputEnabled>
+    <_PowerShellSDKConfigCopyToPublishEnabled Condition="'$(_PowerShellSDKConfigEnabled)' == 'true' and '$(_PowerShellSDKCopyToPublishEnabled)' == 'true'">true</_PowerShellSDKConfigCopyToPublishEnabled>
     <_PowerShellSDKGeneratedConfigPath>$(IntermediateOutputPath)PowerShellSDK\powershell.config.json</_PowerShellSDKGeneratedConfigPath>
   </PropertyGroup>
+
+  <Target Name="_PowerShellSDKValidateOptions">
+    <Error Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(PowerShellSDKAppHostLayout)', '^(?i:None|Root|RuntimeNative|Both)$')) != 'True'"
+           Text="PowerShellSDKAppHostLayout must be one of None, Root, RuntimeNative, or Both." />
+    <Error Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(PowerShellSDKAppHostImplementation)', '^(?i:Auto|MultiPwsh|DotNet)$')) != 'True'"
+           Text="PowerShellSDKAppHostImplementation must be one of Auto, MultiPwsh, or DotNet." />
+    <Error Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(_PowerShellSDKCopyPhasesForItems)', '^(?i:Output|Publish)(;(?i:Output|Publish))*$')) != 'True'"
+           Text="PowerShellSDKCopyPhases must be Output, Publish, or a semicolon-delimited combination such as Output;Publish." />
+    <Error Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(PowerShellSDKConfig)', '^(?i:None|Copy)$')) != 'True'"
+           Text="PowerShellSDKConfig must be None or Copy." />
+    <Error Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(PowerShellSDKConfigOverwriteExisting)', '^(?i:true|false)$')) != 'True'"
+           Text="PowerShellSDKConfigOverwriteExisting must be true or false." />
+    <Error Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(PowerShellSDKLocalizedResources)', '^(?i:None|Copy)$')) != 'True'"
+           Text="PowerShellSDKLocalizedResources must be None or Copy." />
+    <Error Condition="'$(_PowerShellSDKRootAppHostEnabled)' == 'true' and '$(_PowerShellSDKAppHostImplementationValue)' == 'dotnet'"
+           Text="PowerShellSDKAppHostImplementation=DotNet is not available for the Root apphost layout in this SDK package." />
+    <Error Condition="'$(_PowerShellSDKRuntimeNativeAppHostEnabled)' == 'true' and '$(_PowerShellSDKAppHostImplementationValue)' == 'multipwsh'"
+           Text="PowerShellSDKAppHostImplementation=MultiPwsh is not available for the RuntimeNative apphost layout in this SDK package. Use Auto or DotNet until the package includes runtime-native multi-pwsh apphost assets." />
+  </Target>
+
+  <Target Name="_PowerShellSDKValidateImportedOptions"
+          BeforeTargets="PrepareForBuild;CopyFilesToOutputDirectory;ComputeFilesToPublish;Publish"
+          DependsOnTargets="_PowerShellSDKValidateOptions" />
 
   <Target Name="_PowerShellSDKRemoveAutomaticRuntimeNativeCopyItems"
           AfterTargets="ResolvePackageAssets"
@@ -208,7 +242,7 @@
     </ItemGroup>
   </Target>
 
-  <PropertyGroup Condition="'$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True'">
+  <PropertyGroup Condition="'$(_PowerShellSDKRootAppHostEnabled)' == 'true'">
     <_PowerShellSDKAppHostRid Condition="'$(PowerShellSDKAppHostRuntimeIdentifier)' != ''">$(PowerShellSDKAppHostRuntimeIdentifier)</_PowerShellSDKAppHostRid>
     <_PowerShellSDKAppHostRid Condition="'$(_PowerShellSDKAppHostRid)' == '' and '$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</_PowerShellSDKAppHostRid>
     <_PowerShellSDKAppHostRid Condition="'$(_PowerShellSDKAppHostRid)' == '' and '$(NETCoreSdkRuntimeIdentifier)' != ''">$(NETCoreSdkRuntimeIdentifier)</_PowerShellSDKAppHostRid>
@@ -218,9 +252,10 @@
   </PropertyGroup>
 
   <Target Name="_PowerShellSDKResolveAppHost"
-          Condition="'$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True'">
+          DependsOnTargets="_PowerShellSDKValidateOptions"
+          Condition="'$(_PowerShellSDKRootAppHostEnabled)' == 'true'">
     <Error Condition="'$(_PowerShellSDKAppHostRid)' == ''"
-           Text="PowerShellSDKIncludeAppHost is true, but no runtime identifier is available. Set RuntimeIdentifier or PowerShellSDKAppHostRuntimeIdentifier." />
+           Text="PowerShellSDKAppHostLayout includes Root, but no runtime identifier is available. Set RuntimeIdentifier or PowerShellSDKAppHostRuntimeIdentifier." />
 
     <PropertyGroup>
       <_PowerShellSDKAppHostSourceDir>$(MSBuildThisFileDirectory)../tools/apphost/$(_PowerShellSDKAppHostRid)/</_PowerShellSDKAppHostSourceDir>
@@ -230,9 +265,9 @@
     </PropertyGroup>
 
     <Error Condition="!Exists('$(_PowerShellSDKAppHostSourceDir)')"
-           Text="PowerShellSDKIncludeAppHost is true, but this PowerShell SDK package does not include apphost files for '$(_PowerShellSDKAppHostRid)'. Set PowerShellSDKAppHostRuntimeIdentifier to a supported runtime identifier." />
+           Text="PowerShellSDKAppHostLayout includes Root, but this PowerShell SDK package does not include apphost files for '$(_PowerShellSDKAppHostRid)'. Set PowerShellSDKAppHostRuntimeIdentifier to a supported runtime identifier." />
     <Error Condition="!Exists('$(_PowerShellSDKModuleSourceDir)')"
-           Text="PowerShellSDKIncludeAppHost is true, but this PowerShell SDK package does not include module files for runtime group '$(_PowerShellSDKAppHostRuntimeGroup)' and target framework '$(TargetFramework)'." />
+           Text="PowerShellSDKAppHostLayout includes Root, but this PowerShell SDK package does not include module files for runtime group '$(_PowerShellSDKAppHostRuntimeGroup)' and target framework '$(TargetFramework)'." />
 
     <ItemGroup>
       <_PowerShellSDKAppHostFile Include="$(_PowerShellSDKAppHostSourceDir)**/*" />
@@ -244,41 +279,70 @@
   </Target>
 
   <Target Name="_PowerShellSDKResolveRuntimeNativeAppHosts"
-          Condition="'$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'true' or '$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'True'">
-    <Error Condition="'$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers)' != '' and $([System.String]::Copy(';$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers);').Contains(';win-x64;')) and !Exists('$(MSBuildThisFileDirectory)..\runtimes\win-x64\native')"
-           Text="PowerShellSDKIncludeRuntimeNativeAppHosts requested 'win-x64', but this PowerShell SDK package does not include runtimes/win-x64/native." />
-    <Error Condition="'$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers)' != '' and $([System.String]::Copy(';$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers);').Contains(';win-arm64;')) and !Exists('$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native')"
-           Text="PowerShellSDKIncludeRuntimeNativeAppHosts requested 'win-arm64', but this PowerShell SDK package does not include runtimes/win-arm64/native." />
-    <Error Condition="'$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers)' != '' and $([System.String]::Copy(';$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers);').Contains(';linux-x64;')) and !Exists('$(MSBuildThisFileDirectory)..\runtimes\linux-x64\native')"
-           Text="PowerShellSDKIncludeRuntimeNativeAppHosts requested 'linux-x64', but this PowerShell SDK package does not include runtimes/linux-x64/native." />
-    <Error Condition="'$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers)' != '' and $([System.String]::Copy(';$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers);').Contains(';linux-arm64;')) and !Exists('$(MSBuildThisFileDirectory)..\runtimes\linux-arm64\native')"
-           Text="PowerShellSDKIncludeRuntimeNativeAppHosts requested 'linux-arm64', but this PowerShell SDK package does not include runtimes/linux-arm64/native." />
-    <Error Condition="'$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers)' != '' and $([System.String]::Copy(';$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers);').Contains(';osx-x64;')) and !Exists('$(MSBuildThisFileDirectory)..\runtimes\osx-x64\native')"
-           Text="PowerShellSDKIncludeRuntimeNativeAppHosts requested 'osx-x64', but this PowerShell SDK package does not include runtimes/osx-x64/native." />
-    <Error Condition="'$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers)' != '' and $([System.String]::Copy(';$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers);').Contains(';osx-arm64;')) and !Exists('$(MSBuildThisFileDirectory)..\runtimes\osx-arm64\native')"
-           Text="PowerShellSDKIncludeRuntimeNativeAppHosts requested 'osx-arm64', but this PowerShell SDK package does not include runtimes/osx-arm64/native." />
+          DependsOnTargets="_PowerShellSDKValidateOptions"
+          Condition="'$(_PowerShellSDKRuntimeNativeAppHostEnabled)' == 'true'">
+    <PropertyGroup>
+      <_PowerShellSDKRuntimeNativeRequestedRidList>$([System.Text.RegularExpressions.Regex]::Replace('$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers)', '%3[Bb]', ';'))</_PowerShellSDKRuntimeNativeRequestedRidList>
+    </PropertyGroup>
 
     <ItemGroup>
-      <_PowerShellSDKRuntimeNativeWinX64File Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\**\*"
-                                             Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\win-x64\native') and ('$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers)' == '' or $([System.String]::Copy(';$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers);').Contains(';win-x64;')))" />
-      <_PowerShellSDKRuntimeNativeWinArm64File Include="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\**\*"
-                                               Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native') and ('$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers)' == '' or $([System.String]::Copy(';$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers);').Contains(';win-arm64;')))" />
-      <_PowerShellSDKRuntimeNativeLinuxX64File Include="$(MSBuildThisFileDirectory)..\runtimes\linux-x64\native\**\*"
-                                               Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\linux-x64\native') and ('$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers)' == '' or $([System.String]::Copy(';$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers);').Contains(';linux-x64;')))" />
-      <_PowerShellSDKRuntimeNativeLinuxArm64File Include="$(MSBuildThisFileDirectory)..\runtimes\linux-arm64\native\**\*"
-                                                 Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\linux-arm64\native') and ('$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers)' == '' or $([System.String]::Copy(';$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers);').Contains(';linux-arm64;')))" />
-      <_PowerShellSDKRuntimeNativeOsxX64File Include="$(MSBuildThisFileDirectory)..\runtimes\osx-x64\native\**\*"
-                                             Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\osx-x64\native') and ('$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers)' == '' or $([System.String]::Copy(';$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers);').Contains(';osx-x64;')))" />
-      <_PowerShellSDKRuntimeNativeOsxArm64File Include="$(MSBuildThisFileDirectory)..\runtimes\osx-arm64\native\**\*"
-                                               Condition="Exists('$(MSBuildThisFileDirectory)..\runtimes\osx-arm64\native') and ('$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers)' == '' or $([System.String]::Copy(';$(PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers);').Contains(';osx-arm64;')))" />
-      <_PowerShellSDKRuntimeNativeAppHostFile Include="@(_PowerShellSDKRuntimeNativeWinX64File);@(_PowerShellSDKRuntimeNativeWinArm64File);@(_PowerShellSDKRuntimeNativeLinuxX64File);@(_PowerShellSDKRuntimeNativeLinuxArm64File);@(_PowerShellSDKRuntimeNativeOsxX64File);@(_PowerShellSDKRuntimeNativeOsxArm64File)" />
+      <_PowerShellSDKRuntimeNativeSupportedRid Include="win-x64">
+        <ExecutableName>pwsh.exe</ExecutableName>
+      </_PowerShellSDKRuntimeNativeSupportedRid>
+      <_PowerShellSDKRuntimeNativeSupportedRid Include="win-arm64">
+        <ExecutableName>pwsh.exe</ExecutableName>
+      </_PowerShellSDKRuntimeNativeSupportedRid>
+      <_PowerShellSDKRuntimeNativeSupportedRid Include="linux-x64">
+        <ExecutableName>pwsh</ExecutableName>
+        <RequiresChmod>true</RequiresChmod>
+      </_PowerShellSDKRuntimeNativeSupportedRid>
+      <_PowerShellSDKRuntimeNativeSupportedRid Include="linux-arm64">
+        <ExecutableName>pwsh</ExecutableName>
+        <RequiresChmod>true</RequiresChmod>
+      </_PowerShellSDKRuntimeNativeSupportedRid>
+      <_PowerShellSDKRuntimeNativeSupportedRid Include="osx-x64">
+        <ExecutableName>pwsh</ExecutableName>
+        <RequiresChmod>true</RequiresChmod>
+      </_PowerShellSDKRuntimeNativeSupportedRid>
+      <_PowerShellSDKRuntimeNativeSupportedRid Include="osx-arm64">
+        <ExecutableName>pwsh</ExecutableName>
+        <RequiresChmod>true</RequiresChmod>
+      </_PowerShellSDKRuntimeNativeSupportedRid>
+
+      <_PowerShellSDKRuntimeNativeRequestedRid Include="$([MSBuild]::Unescape('$(_PowerShellSDKRuntimeNativeRequestedRidList)'))"
+                                               Condition="'$(_PowerShellSDKRuntimeNativeRequestedRidList)' != ''" />
+      <_PowerShellSDKRuntimeNativeUnsupportedRid Include="@(_PowerShellSDKRuntimeNativeRequestedRid)"
+                                                 Condition="'%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'win-x64' and '%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'win-arm64' and '%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'linux-x64' and '%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'linux-arm64' and '%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'osx-x64' and '%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'osx-arm64'" />
+      <_PowerShellSDKRuntimeNativeSelectedRid Include="@(_PowerShellSDKRuntimeNativeSupportedRid)"
+                                              Condition="'$(_PowerShellSDKRuntimeNativeRequestedRidList)' == '' or $([System.String]::Copy(';$(_PowerShellSDKRuntimeNativeRequestedRidList);').Contains(';%(_PowerShellSDKRuntimeNativeSupportedRid.Identity);')) == 'True'">
+        <RelativeDirectory>runtimes/%(_PowerShellSDKRuntimeNativeSupportedRid.Identity)/native</RelativeDirectory>
+        <SourceDirectory>$(MSBuildThisFileDirectory)..\runtimes\%(_PowerShellSDKRuntimeNativeSupportedRid.Identity)\native\</SourceDirectory>
+      </_PowerShellSDKRuntimeNativeSelectedRid>
+      <_PowerShellSDKRuntimeNativeMissingRid Include="@(_PowerShellSDKRuntimeNativeSelectedRid)"
+                                             Condition="!Exists('%(_PowerShellSDKRuntimeNativeSelectedRid.SourceDirectory)')" />
+      <_PowerShellSDKRuntimeNativeMissingAppHost Include="@(_PowerShellSDKRuntimeNativeSelectedRid)"
+                                                 Condition="Exists('%(_PowerShellSDKRuntimeNativeSelectedRid.SourceDirectory)') and !Exists('%(_PowerShellSDKRuntimeNativeSelectedRid.SourceDirectory)%(_PowerShellSDKRuntimeNativeSelectedRid.ExecutableName)')" />
+      <_PowerShellSDKRuntimeNativeAppHostFile Include="@(_PowerShellSDKRuntimeNativeSelectedRid->'%(SourceDirectory)%(ExecutableName)')">
+        <RuntimeIdentifier>%(_PowerShellSDKRuntimeNativeSelectedRid.Identity)</RuntimeIdentifier>
+        <RelativeDirectory>%(_PowerShellSDKRuntimeNativeSelectedRid.RelativeDirectory)</RelativeDirectory>
+        <RequiresChmod>%(_PowerShellSDKRuntimeNativeSelectedRid.RequiresChmod)</RequiresChmod>
+      </_PowerShellSDKRuntimeNativeAppHostFile>
+      <_PowerShellSDKRuntimeNativeChmodRelativePath Include="@(_PowerShellSDKRuntimeNativeAppHostFile->'%(RelativeDirectory)/%(Filename)%(Extension)')"
+                                                    Condition="'%(_PowerShellSDKRuntimeNativeAppHostFile.RequiresChmod)' == 'true'" />
     </ItemGroup>
+
+    <Error Condition="'@(_PowerShellSDKRuntimeNativeUnsupportedRid)' != ''"
+           Text="PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers contains unsupported runtime identifier(s): @(_PowerShellSDKRuntimeNativeUnsupportedRid, ', '). Supported runtime identifiers are @(_PowerShellSDKRuntimeNativeSupportedRid, ', ')." />
+    <Error Condition="'@(_PowerShellSDKRuntimeNativeMissingRid)' != ''"
+           Text="PowerShellSDKAppHostLayout includes RuntimeNative, but this PowerShell SDK package does not include runtime-native apphost directories for: @(_PowerShellSDKRuntimeNativeMissingRid, ', ')." />
+    <Error Condition="'@(_PowerShellSDKRuntimeNativeMissingAppHost)' != ''"
+           Text="PowerShellSDKAppHostLayout includes RuntimeNative, but this PowerShell SDK package does not include runtime-native apphost executables for: @(_PowerShellSDKRuntimeNativeMissingAppHost, ', ')." />
 
     <PropertyGroup>
       <_PowerShellSDKRuntimeNativeSharedPayloadRid Condition="'$(PowerShellSDKRuntimeNativeSharedPayloadRuntimeIdentifier)' != ''">$(PowerShellSDKRuntimeNativeSharedPayloadRuntimeIdentifier)</_PowerShellSDKRuntimeNativeSharedPayloadRid>
-      <_PowerShellSDKRuntimeNativeSharedPayloadRid Condition="'$(_PowerShellSDKRuntimeNativeSharedPayloadRid)' == '' and '$(PowerShellSDKAppHostRuntimeIdentifier)' != ''">$(PowerShellSDKAppHostRuntimeIdentifier)</_PowerShellSDKRuntimeNativeSharedPayloadRid>
       <_PowerShellSDKRuntimeNativeSharedPayloadRid Condition="'$(_PowerShellSDKRuntimeNativeSharedPayloadRid)' == '' and '$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</_PowerShellSDKRuntimeNativeSharedPayloadRid>
       <_PowerShellSDKRuntimeNativeSharedPayloadRid Condition="'$(_PowerShellSDKRuntimeNativeSharedPayloadRid)' == '' and '$(NETCoreSdkRuntimeIdentifier)' != ''">$(NETCoreSdkRuntimeIdentifier)</_PowerShellSDKRuntimeNativeSharedPayloadRid>
+      <_PowerShellSDKRuntimeNativeSharedPayloadRid Condition="'$(_PowerShellSDKRuntimeNativeSharedPayloadRid)' == '' and '$(PowerShellSDKAppHostRuntimeIdentifier)' != ''">$(PowerShellSDKAppHostRuntimeIdentifier)</_PowerShellSDKRuntimeNativeSharedPayloadRid>
       <_PowerShellSDKRuntimeNativeSharedPayloadRid Condition="'$(_PowerShellSDKRuntimeNativeSharedPayloadRid)' == 'win7-x64'">win-x64</_PowerShellSDKRuntimeNativeSharedPayloadRid>
       <_PowerShellSDKRuntimeNativeSharedPayloadGroup>unix</_PowerShellSDKRuntimeNativeSharedPayloadGroup>
       <_PowerShellSDKRuntimeNativeSharedPayloadGroup Condition="$([System.String]::Copy('$(_PowerShellSDKRuntimeNativeSharedPayloadRid)').StartsWith('win'))">win</_PowerShellSDKRuntimeNativeSharedPayloadGroup>
@@ -292,13 +356,13 @@
     </PropertyGroup>
 
     <Error Condition="'$(_PowerShellSDKRuntimeNativeSharedPayloadRid)' == ''"
-           Text="PowerShellSDKIncludeRuntimeNativeAppHosts is true, but no runtime identifier is available for the shared PowerShell payload. Set RuntimeIdentifier, NETCoreSdkRuntimeIdentifier, PowerShellSDKRuntimeNativeSharedPayloadRuntimeIdentifier, or PowerShellSDKAppHostRuntimeIdentifier." />
+           Text="PowerShellSDKAppHostLayout includes RuntimeNative, but no runtime identifier is available for the shared PowerShell payload. Set RuntimeIdentifier, NETCoreSdkRuntimeIdentifier, PowerShellSDKRuntimeNativeSharedPayloadRuntimeIdentifier, or PowerShellSDKAppHostRuntimeIdentifier." />
     <Error Condition="!Exists('$(_PowerShellSDKRuntimeNativeSharedAppHostSourceDir)')"
-           Text="PowerShellSDKIncludeRuntimeNativeAppHosts is true, but this PowerShell SDK package does not include shared apphost payload files for '$(_PowerShellSDKRuntimeNativeSharedPayloadRid)'." />
+           Text="PowerShellSDKAppHostLayout includes RuntimeNative, but this PowerShell SDK package does not include shared apphost payload files for '$(_PowerShellSDKRuntimeNativeSharedPayloadRid)'." />
     <Error Condition="!Exists('$(_PowerShellSDKRuntimeNativeSharedModuleSourceDir)')"
-           Text="PowerShellSDKIncludeRuntimeNativeAppHosts is true, but this PowerShell SDK package does not include module files for runtime group '$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)' and shared payload target framework '$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)'." />
+           Text="PowerShellSDKAppHostLayout includes RuntimeNative, but this PowerShell SDK package does not include module files for runtime group '$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)' and shared payload target framework '$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)'." />
     <Error Condition="!Exists('$(_PowerShellSDKRuntimeNativeSharedRuntimeSourceDir)')"
-           Text="PowerShellSDKIncludeRuntimeNativeAppHosts is true, but this PowerShell SDK package does not include runtime files for runtime group '$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)' and shared payload target framework '$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)'." />
+           Text="PowerShellSDKAppHostLayout includes RuntimeNative, but this PowerShell SDK package does not include runtime files for runtime group '$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)' and shared payload target framework '$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)'." />
 
     <ItemGroup>
       <_PowerShellSDKRuntimeNativeSharedAppHostFile Include="$(_PowerShellSDKRuntimeNativeSharedAppHostSourceDir)pwsh.dll;$(_PowerShellSDKRuntimeNativeSharedAppHostSourceDir)pwsh.runtimeconfig.json" />
@@ -310,41 +374,43 @@
     </ItemGroup>
 
     <Error Condition="'@(_PowerShellSDKRuntimeNativeAppHostFile)' == ''"
-           Text="PowerShellSDKIncludeRuntimeNativeAppHosts is true, but no runtime-native apphost files were selected. Set PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers to a RID included in this package." />
+           Text="PowerShellSDKAppHostLayout includes RuntimeNative, but no runtime-native apphost files were selected. Set PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers to a RID included in this package." />
   </Target>
 
   <Target Name="_PowerShellSDKResolvePSGalleryModules"
-          Condition="'$(PowerShellSDKIncludePSGalleryModules)' == 'true' or '$(PowerShellSDKIncludePSGalleryModules)' == 'True'">
+          DependsOnTargets="_PowerShellSDKValidateOptions"
+          Condition="'$(_PowerShellSDKPSGalleryModulesEnabled)' == 'true'">
     <PropertyGroup>
       <_PowerShellSDKPSGalleryModuleSourceRoot>$(MSBuildThisFileDirectory)psgallery-modules\</_PowerShellSDKPSGalleryModuleSourceRoot>
-      <_PowerShellSDKPSGalleryModuleNamesForItems>$([System.Text.RegularExpressions.Regex]::Replace('$(PowerShellSDKPSGalleryModuleNames)', '%3[Bb]', ';'))</_PowerShellSDKPSGalleryModuleNamesForItems>
+      <_PowerShellSDKPSGalleryModuleNamesForItems Condition="'$(_PowerShellSDKPSGalleryModulesValue)' != 'all'">$([System.Text.RegularExpressions.Regex]::Replace('$(PowerShellSDKPSGalleryModules)', '%3[Bb]', ';'))</_PowerShellSDKPSGalleryModuleNamesForItems>
     </PropertyGroup>
 
     <Error Condition="!Exists('$(_PowerShellSDKPSGalleryModuleSourceRoot)')"
-           Text="PowerShellSDKIncludePSGalleryModules is true, but this PowerShell SDK package does not include PSGallery module files." />
+           Text="PowerShellSDKPSGalleryModules is enabled, but this PowerShell SDK package does not include PSGallery module files." />
 
     <ItemGroup>
-      <_PowerShellSDKRequestedPSGalleryModule Include="$(_PowerShellSDKPSGalleryModuleNamesForItems)"
-                                             Condition="'$(PowerShellSDKPSGalleryModuleNames)' != ''" />
+      <_PowerShellSDKRequestedPSGalleryModule Include="$([MSBuild]::Unescape('$(_PowerShellSDKPSGalleryModuleNamesForItems)'))"
+                                             Condition="'$(_PowerShellSDKPSGalleryModuleNamesForItems)' != ''" />
       <_PowerShellSDKMissingPSGalleryModule Include="@(_PowerShellSDKRequestedPSGalleryModule)"
-                                           Condition="'$(PowerShellSDKPSGalleryModuleNames)' != '' and !Exists('$(_PowerShellSDKPSGalleryModuleSourceRoot)%(_PowerShellSDKRequestedPSGalleryModule.Identity)')" />
+                                           Condition="'$(_PowerShellSDKPSGalleryModuleNamesForItems)' != '' and !Exists('$(_PowerShellSDKPSGalleryModuleSourceRoot)%(_PowerShellSDKRequestedPSGalleryModule.Identity)')" />
       <_PowerShellSDKAllPSGalleryModuleFile Include="$(_PowerShellSDKPSGalleryModuleSourceRoot)**\*.*"
-                                           Condition="'$(PowerShellSDKPSGalleryModuleNames)' == ''">
+                                           Condition="'$(_PowerShellSDKPSGalleryModulesValue)' == 'all'">
       </_PowerShellSDKAllPSGalleryModuleFile>
       <_PowerShellSDKSelectedPSGalleryModuleFile Include="$(_PowerShellSDKPSGalleryModuleSourceRoot)%(_PowerShellSDKRequestedPSGalleryModule.Identity)\**\*.*"
-                                                Condition="'$(PowerShellSDKPSGalleryModuleNames)' != ''">
+                                                Condition="'$(_PowerShellSDKPSGalleryModuleNamesForItems)' != ''">
         <PowerShellSDKPSGalleryModuleName>%(_PowerShellSDKRequestedPSGalleryModule.Identity)</PowerShellSDKPSGalleryModuleName>
       </_PowerShellSDKSelectedPSGalleryModuleFile>
       <_PowerShellSDKPSGalleryModuleFile Include="@(_PowerShellSDKAllPSGalleryModuleFile);@(_PowerShellSDKSelectedPSGalleryModuleFile)" />
     </ItemGroup>
 
     <Error Condition="'@(_PowerShellSDKMissingPSGalleryModule)' != ''"
-           Text="PowerShellSDKIncludePSGalleryModules requested PSGallery module(s) that are not included in this package: @(_PowerShellSDKMissingPSGalleryModule, ', ')." />
+           Text="PowerShellSDKPSGalleryModules requested module(s) that are not included in this package: @(_PowerShellSDKMissingPSGalleryModule, ', ')." />
     <Error Condition="'@(_PowerShellSDKPSGalleryModuleFile)' == ''"
-           Text="PowerShellSDKIncludePSGalleryModules is true, but no PSGallery module files were selected." />
+           Text="PowerShellSDKPSGalleryModules is enabled, but no PSGallery module files were selected." />
   </Target>
 
   <Target Name="_PowerShellSDKGenerateConfig"
+          DependsOnTargets="_PowerShellSDKValidateOptions"
           Condition="'$(_PowerShellSDKConfigEnabled)' == 'true'">
     <Error Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(PowerShellSDKConfigExecutionPolicy)', '^(?i:AllSigned|Bypass|Default|RemoteSigned|Restricted|Undefined|Unrestricted)$')) != 'True'"
            Text="PowerShellSDKConfigExecutionPolicy must be one of AllSigned, Bypass, Default, RemoteSigned, Restricted, Undefined, or Unrestricted." />
@@ -364,7 +430,7 @@
   <Target Name="PowerShellSDKCopyAppHostToOutput"
           DependsOnTargets="_PowerShellSDKResolveAppHost"
           AfterTargets="CopyFilesToOutputDirectory"
-          Condition="'$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True'">
+          Condition="'$(_PowerShellSDKRootCopyToOutputEnabled)' == 'true'">
     <Copy SourceFiles="@(_PowerShellSDKAppHostFile)"
           DestinationFiles="@(_PowerShellSDKAppHostFile->'$(OutDir)%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
@@ -378,7 +444,7 @@
   <Target Name="PowerShellSDKCopyAppHostCompanionFilesToOutput"
           DependsOnTargets="_PowerShellSDKResolveAppHost"
           AfterTargets="PowerShellSDKCopyAppHostToOutput"
-          Condition="'$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True'">
+          Condition="'$(_PowerShellSDKRootCopyToOutputEnabled)' == 'true'">
     <Copy SourceFiles="@(_PowerShellSDKAppHostCompanionFile)"
           DestinationFiles="@(_PowerShellSDKAppHostCompanionFile->'$(OutDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true"
@@ -388,9 +454,9 @@
   <Target Name="PowerShellSDKCopyAppHostLocalizedResourcesToOutput"
           DependsOnTargets="_PowerShellSDKResolveAppHost"
           AfterTargets="PowerShellSDKCopyAppHostToOutput"
-          Condition="('$(_PowerShellSDKLocalizedResourcesCopyToOutputEnabled)' == 'true') and ('$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True')">
+          Condition="'$(_PowerShellSDKLocalizedResourcesCopyToOutputEnabled)' == 'true' and '$(_PowerShellSDKRootAppHostEnabled)' == 'true'">
     <Error Condition="'@(_PowerShellSDKAppHostLocalizedResourceFile)' == ''"
-           Text="PowerShellSDKIncludeLocalizedResources is true, but this PowerShell SDK package does not include localized resources for runtime group '$(_PowerShellSDKAppHostRuntimeGroup)' and target framework '$(TargetFramework)'." />
+           Text="PowerShellSDKLocalizedResources=Copy, but this PowerShell SDK package does not include localized resources for runtime group '$(_PowerShellSDKAppHostRuntimeGroup)' and target framework '$(TargetFramework)'." />
     <Copy SourceFiles="@(_PowerShellSDKAppHostLocalizedResourceFile)"
           DestinationFiles="@(_PowerShellSDKAppHostLocalizedResourceFile->'$(OutDir)%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
@@ -399,7 +465,7 @@
   <Target Name="PowerShellSDKCopyRuntimeNativeAppHostsToOutput"
           DependsOnTargets="_PowerShellSDKResolveRuntimeNativeAppHosts"
           AfterTargets="CopyFilesToOutputDirectory"
-          Condition="('$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'true' or '$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'True') and ('$(PowerShellSDKRuntimeNativeAppHostCopyToOutput)' == 'true' or '$(PowerShellSDKRuntimeNativeAppHostCopyToOutput)' == 'True')">
+          Condition="'$(_PowerShellSDKRuntimeNativeCopyToOutputEnabled)' == 'true'">
     <ItemGroup>
       <_PowerShellSDKAutomaticSharedOutputPayloadFile Include="$(OutDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/*.dll;$(OutDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/*.xml;$(OutDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/*.config" />
     </ItemGroup>
@@ -416,30 +482,9 @@
     <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeSharedModuleFile)"
           DestinationFiles="@(_PowerShellSDKRuntimeNativeSharedModuleFile->'$(OutDir)Modules/%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
-    <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeWinX64File)"
-          DestinationFiles="@(_PowerShellSDKRuntimeNativeWinX64File->'$(OutDir)runtimes/win-x64/native/%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true"
-          Condition="'@(_PowerShellSDKRuntimeNativeWinX64File)' != ''" />
-    <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeWinArm64File)"
-          DestinationFiles="@(_PowerShellSDKRuntimeNativeWinArm64File->'$(OutDir)runtimes/win-arm64/native/%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true"
-          Condition="'@(_PowerShellSDKRuntimeNativeWinArm64File)' != ''" />
-    <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeLinuxX64File)"
-          DestinationFiles="@(_PowerShellSDKRuntimeNativeLinuxX64File->'$(OutDir)runtimes/linux-x64/native/%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true"
-          Condition="'@(_PowerShellSDKRuntimeNativeLinuxX64File)' != ''" />
-    <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeLinuxArm64File)"
-          DestinationFiles="@(_PowerShellSDKRuntimeNativeLinuxArm64File->'$(OutDir)runtimes/linux-arm64/native/%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true"
-          Condition="'@(_PowerShellSDKRuntimeNativeLinuxArm64File)' != ''" />
-    <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeOsxX64File)"
-          DestinationFiles="@(_PowerShellSDKRuntimeNativeOsxX64File->'$(OutDir)runtimes/osx-x64/native/%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true"
-          Condition="'@(_PowerShellSDKRuntimeNativeOsxX64File)' != ''" />
-    <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeOsxArm64File)"
-          DestinationFiles="@(_PowerShellSDKRuntimeNativeOsxArm64File->'$(OutDir)runtimes/osx-arm64/native/%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true"
-          Condition="'@(_PowerShellSDKRuntimeNativeOsxArm64File)' != ''" />
+    <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeAppHostFile)"
+          DestinationFiles="@(_PowerShellSDKRuntimeNativeAppHostFile->'$(OutDir)%(RelativeDirectory)/%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
     <ItemGroup>
       <_PowerShellSDKRuntimeNativeSharedDependencySourceFile Include="$(OutDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadRid)/lib/**/*.dll" />
       <_PowerShellSDKRuntimeNativeSharedDependencyFile Include="@(_PowerShellSDKRuntimeNativeSharedDependencySourceFile)"
@@ -453,22 +498,16 @@
           DestinationFiles="@(_PowerShellSDKRuntimeNativeSharedCompanionFile->'$(OutDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true"
           Condition="'@(_PowerShellSDKRuntimeNativeSharedCompanionFile)' != ''" />
-    <Exec Command="chmod +x &quot;$(OutDir)runtimes/linux-x64/native/pwsh&quot;"
-          Condition="'$(OS)' != 'Windows_NT' and Exists('$(OutDir)runtimes/linux-x64/native/pwsh')" />
-    <Exec Command="chmod +x &quot;$(OutDir)runtimes/linux-arm64/native/pwsh&quot;"
-          Condition="'$(OS)' != 'Windows_NT' and Exists('$(OutDir)runtimes/linux-arm64/native/pwsh')" />
-    <Exec Command="chmod +x &quot;$(OutDir)runtimes/osx-x64/native/pwsh&quot;"
-          Condition="'$(OS)' != 'Windows_NT' and Exists('$(OutDir)runtimes/osx-x64/native/pwsh')" />
-    <Exec Command="chmod +x &quot;$(OutDir)runtimes/osx-arm64/native/pwsh&quot;"
-          Condition="'$(OS)' != 'Windows_NT' and Exists('$(OutDir)runtimes/osx-arm64/native/pwsh')" />
+    <Exec Command="chmod +x &quot;$(OutDir)%(_PowerShellSDKRuntimeNativeChmodRelativePath.Identity)&quot;"
+          Condition="'$(OS)' != 'Windows_NT' and Exists('$(OutDir)%(_PowerShellSDKRuntimeNativeChmodRelativePath.Identity)')" />
   </Target>
 
   <Target Name="PowerShellSDKCopyRuntimeNativeLocalizedResourcesToOutput"
           DependsOnTargets="_PowerShellSDKResolveRuntimeNativeAppHosts"
           AfterTargets="PowerShellSDKCopyRuntimeNativeAppHostsToOutput"
-          Condition="('$(_PowerShellSDKLocalizedResourcesCopyToOutputEnabled)' == 'true') and ('$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'true' or '$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'True')">
+          Condition="'$(_PowerShellSDKLocalizedResourcesCopyToOutputEnabled)' == 'true' and '$(_PowerShellSDKRuntimeNativeAppHostEnabled)' == 'true'">
     <Error Condition="'@(_PowerShellSDKRuntimeNativeSharedLocalizedResourceFile)' == ''"
-           Text="PowerShellSDKIncludeLocalizedResources is true, but this PowerShell SDK package does not include localized resources for runtime group '$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)' and target framework '$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)'." />
+           Text="PowerShellSDKLocalizedResources=Copy, but this PowerShell SDK package does not include localized resources for runtime group '$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)' and target framework '$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)'." />
     <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeSharedLocalizedResourceFile)"
           DestinationFiles="@(_PowerShellSDKRuntimeNativeSharedLocalizedResourceFile->'$(OutDir)%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
@@ -495,13 +534,13 @@
     <Copy SourceFiles="$(_PowerShellSDKGeneratedConfigPath)"
           DestinationFiles="$(OutDir)powershell.config.json"
           SkipUnchangedFiles="true"
-          Condition="!Exists('$(OutDir)powershell.config.json') or '$(PowerShellSDKConfigOverwriteExisting)' == 'true' or '$(PowerShellSDKConfigOverwriteExisting)' == 'True'" />
+          Condition="!Exists('$(OutDir)powershell.config.json') or '$(_PowerShellSDKConfigOverwriteExistingValue)' == 'true'" />
   </Target>
 
   <Target Name="PowerShellSDKAddAppHostToPublish"
           DependsOnTargets="_PowerShellSDKResolveAppHost"
           BeforeTargets="ComputeFilesToPublish"
-          Condition="'$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True'">
+          Condition="'$(_PowerShellSDKRootCopyToPublishEnabled)' == 'true'">
     <ItemGroup>
       <ResolvedFileToPublish Include="@(_PowerShellSDKAppHostFile)">
         <RelativePath>%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
@@ -517,7 +556,7 @@
   <Target Name="PowerShellSDKAddAppHostCompanionFilesToPublish"
           DependsOnTargets="_PowerShellSDKResolveAppHost"
           BeforeTargets="ComputeFilesToPublish"
-          Condition="'$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True'">
+          Condition="'$(_PowerShellSDKRootCopyToPublishEnabled)' == 'true'">
     <ItemGroup>
       <ResolvedFileToPublish Include="@(_PowerShellSDKAppHostCompanionFile)"
                              Condition="'@(_PowerShellSDKAppHostCompanionFile)' != ''">
@@ -530,9 +569,9 @@
   <Target Name="PowerShellSDKCopyAppHostLocalizedResourcesToPublish"
           DependsOnTargets="_PowerShellSDKResolveAppHost"
           AfterTargets="Publish"
-          Condition="('$(_PowerShellSDKLocalizedResourcesCopyToPublishEnabled)' == 'true') and ('$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True')">
+          Condition="'$(_PowerShellSDKLocalizedResourcesCopyToPublishEnabled)' == 'true' and '$(_PowerShellSDKRootAppHostEnabled)' == 'true'">
     <Error Condition="'@(_PowerShellSDKAppHostLocalizedResourceFile)' == ''"
-           Text="PowerShellSDKIncludeLocalizedResources is true, but this PowerShell SDK package does not include localized resources for runtime group '$(_PowerShellSDKAppHostRuntimeGroup)' and target framework '$(TargetFramework)'." />
+           Text="PowerShellSDKLocalizedResources=Copy, but this PowerShell SDK package does not include localized resources for runtime group '$(_PowerShellSDKAppHostRuntimeGroup)' and target framework '$(TargetFramework)'." />
     <Copy SourceFiles="@(_PowerShellSDKAppHostLocalizedResourceFile)"
           DestinationFiles="@(_PowerShellSDKAppHostLocalizedResourceFile->'$(PublishDir)%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
@@ -541,7 +580,7 @@
   <Target Name="PowerShellSDKAddRuntimeNativeAppHostsToPublish"
           DependsOnTargets="_PowerShellSDKResolveRuntimeNativeAppHosts"
           BeforeTargets="ComputeFilesToPublish"
-          Condition="('$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'true' or '$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'True') and ('$(PowerShellSDKRuntimeNativeAppHostCopyToPublish)' == 'true' or '$(PowerShellSDKRuntimeNativeAppHostCopyToPublish)' == 'True')">
+          Condition="'$(_PowerShellSDKRuntimeNativeCopyToPublishEnabled)' == 'true'">
     <ItemGroup>
       <ResolvedFileToPublish Include="@(_PowerShellSDKRuntimeNativeSharedRuntimeFile)">
         <RelativePath>%(_PowerShellSDKRuntimeNativeSharedRuntimeFile.Filename)%(_PowerShellSDKRuntimeNativeSharedRuntimeFile.Extension)</RelativePath>
@@ -564,33 +603,8 @@
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
         <PowerShellSDKRuntimeNativeSharedPayload>true</PowerShellSDKRuntimeNativeSharedPayload>
       </ResolvedFileToPublish>
-      <ResolvedFileToPublish Include="@(_PowerShellSDKRuntimeNativeWinX64File)">
-        <RelativePath>runtimes\win-x64\native\%(_PowerShellSDKRuntimeNativeWinX64File.RecursiveDir)%(_PowerShellSDKRuntimeNativeWinX64File.Filename)%(_PowerShellSDKRuntimeNativeWinX64File.Extension)</RelativePath>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-        <PowerShellSDKRuntimeNativeAppHost>true</PowerShellSDKRuntimeNativeAppHost>
-      </ResolvedFileToPublish>
-      <ResolvedFileToPublish Include="@(_PowerShellSDKRuntimeNativeWinArm64File)">
-        <RelativePath>runtimes\win-arm64\native\%(_PowerShellSDKRuntimeNativeWinArm64File.RecursiveDir)%(_PowerShellSDKRuntimeNativeWinArm64File.Filename)%(_PowerShellSDKRuntimeNativeWinArm64File.Extension)</RelativePath>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-        <PowerShellSDKRuntimeNativeAppHost>true</PowerShellSDKRuntimeNativeAppHost>
-      </ResolvedFileToPublish>
-      <ResolvedFileToPublish Include="@(_PowerShellSDKRuntimeNativeLinuxX64File)">
-        <RelativePath>runtimes\linux-x64\native\%(_PowerShellSDKRuntimeNativeLinuxX64File.RecursiveDir)%(_PowerShellSDKRuntimeNativeLinuxX64File.Filename)%(_PowerShellSDKRuntimeNativeLinuxX64File.Extension)</RelativePath>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-        <PowerShellSDKRuntimeNativeAppHost>true</PowerShellSDKRuntimeNativeAppHost>
-      </ResolvedFileToPublish>
-      <ResolvedFileToPublish Include="@(_PowerShellSDKRuntimeNativeLinuxArm64File)">
-        <RelativePath>runtimes\linux-arm64\native\%(_PowerShellSDKRuntimeNativeLinuxArm64File.RecursiveDir)%(_PowerShellSDKRuntimeNativeLinuxArm64File.Filename)%(_PowerShellSDKRuntimeNativeLinuxArm64File.Extension)</RelativePath>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-        <PowerShellSDKRuntimeNativeAppHost>true</PowerShellSDKRuntimeNativeAppHost>
-      </ResolvedFileToPublish>
-      <ResolvedFileToPublish Include="@(_PowerShellSDKRuntimeNativeOsxX64File)">
-        <RelativePath>runtimes\osx-x64\native\%(_PowerShellSDKRuntimeNativeOsxX64File.RecursiveDir)%(_PowerShellSDKRuntimeNativeOsxX64File.Filename)%(_PowerShellSDKRuntimeNativeOsxX64File.Extension)</RelativePath>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-        <PowerShellSDKRuntimeNativeAppHost>true</PowerShellSDKRuntimeNativeAppHost>
-      </ResolvedFileToPublish>
-      <ResolvedFileToPublish Include="@(_PowerShellSDKRuntimeNativeOsxArm64File)">
-        <RelativePath>runtimes\osx-arm64\native\%(_PowerShellSDKRuntimeNativeOsxArm64File.RecursiveDir)%(_PowerShellSDKRuntimeNativeOsxArm64File.Filename)%(_PowerShellSDKRuntimeNativeOsxArm64File.Extension)</RelativePath>
+      <ResolvedFileToPublish Include="@(_PowerShellSDKRuntimeNativeAppHostFile)">
+        <RelativePath>%(_PowerShellSDKRuntimeNativeAppHostFile.RelativeDirectory)\%(_PowerShellSDKRuntimeNativeAppHostFile.Filename)%(_PowerShellSDKRuntimeNativeAppHostFile.Extension)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
         <PowerShellSDKRuntimeNativeAppHost>true</PowerShellSDKRuntimeNativeAppHost>
       </ResolvedFileToPublish>
@@ -600,9 +614,9 @@
   <Target Name="PowerShellSDKCopyRuntimeNativeLocalizedResourcesToPublish"
           DependsOnTargets="_PowerShellSDKResolveRuntimeNativeAppHosts"
           AfterTargets="Publish"
-          Condition="('$(_PowerShellSDKLocalizedResourcesCopyToPublishEnabled)' == 'true') and ('$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'true' or '$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'True') and ('$(PowerShellSDKRuntimeNativeAppHostCopyToPublish)' == 'true' or '$(PowerShellSDKRuntimeNativeAppHostCopyToPublish)' == 'True')">
+          Condition="'$(_PowerShellSDKLocalizedResourcesCopyToPublishEnabled)' == 'true' and '$(_PowerShellSDKRuntimeNativeCopyToPublishEnabled)' == 'true'">
     <Error Condition="'@(_PowerShellSDKRuntimeNativeSharedLocalizedResourceFile)' == ''"
-           Text="PowerShellSDKIncludeLocalizedResources is true, but this PowerShell SDK package does not include localized resources for runtime group '$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)' and target framework '$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)'." />
+           Text="PowerShellSDKLocalizedResources=Copy, but this PowerShell SDK package does not include localized resources for runtime group '$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)' and target framework '$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)'." />
     <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeSharedLocalizedResourceFile)"
           DestinationFiles="@(_PowerShellSDKRuntimeNativeSharedLocalizedResourceFile->'$(PublishDir)%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
@@ -628,22 +642,17 @@
 
   <Target Name="PowerShellSDKChmodPublishedAppHost"
           AfterTargets="Publish"
-          Condition="'$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True'">
+          Condition="'$(_PowerShellSDKRootCopyToPublishEnabled)' == 'true'">
     <Exec Command="chmod +x &quot;$(PublishDir)pwsh&quot;"
           Condition="'$(OS)' != 'Windows_NT' and Exists('$(PublishDir)pwsh')" />
   </Target>
 
   <Target Name="PowerShellSDKChmodPublishedRuntimeNativeAppHosts"
+          DependsOnTargets="_PowerShellSDKResolveRuntimeNativeAppHosts"
           AfterTargets="Publish"
-          Condition="'$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'true' or '$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'True'">
-    <Exec Command="chmod +x &quot;$(PublishDir)runtimes/linux-x64/native/pwsh&quot;"
-          Condition="'$(OS)' != 'Windows_NT' and Exists('$(PublishDir)runtimes/linux-x64/native/pwsh')" />
-    <Exec Command="chmod +x &quot;$(PublishDir)runtimes/linux-arm64/native/pwsh&quot;"
-          Condition="'$(OS)' != 'Windows_NT' and Exists('$(PublishDir)runtimes/linux-arm64/native/pwsh')" />
-    <Exec Command="chmod +x &quot;$(PublishDir)runtimes/osx-x64/native/pwsh&quot;"
-          Condition="'$(OS)' != 'Windows_NT' and Exists('$(PublishDir)runtimes/osx-x64/native/pwsh')" />
-    <Exec Command="chmod +x &quot;$(PublishDir)runtimes/osx-arm64/native/pwsh&quot;"
-          Condition="'$(OS)' != 'Windows_NT' and Exists('$(PublishDir)runtimes/osx-arm64/native/pwsh')" />
+          Condition="'$(_PowerShellSDKRuntimeNativeCopyToPublishEnabled)' == 'true'">
+    <Exec Command="chmod +x &quot;$(PublishDir)%(_PowerShellSDKRuntimeNativeChmodRelativePath.Identity)&quot;"
+          Condition="'$(OS)' != 'Windows_NT' and Exists('$(PublishDir)%(_PowerShellSDKRuntimeNativeChmodRelativePath.Identity)')" />
   </Target>
 
   <Target Name="PowerShellSDKCopyConfigToPublish"
@@ -653,13 +662,13 @@
     <Copy SourceFiles="$(_PowerShellSDKGeneratedConfigPath)"
           DestinationFiles="$(PublishDir)powershell.config.json"
           SkipUnchangedFiles="true"
-          Condition="!Exists('$(PublishDir)powershell.config.json') or '$(PowerShellSDKConfigOverwriteExisting)' == 'true' or '$(PowerShellSDKConfigOverwriteExisting)' == 'True'" />
+          Condition="!Exists('$(PublishDir)powershell.config.json') or '$(_PowerShellSDKConfigOverwriteExistingValue)' == 'true'" />
   </Target>
 
   <Target Name="PowerShellSDKCopyRuntimeNativeSharedPublishDependencies"
           DependsOnTargets="_PowerShellSDKResolveRuntimeNativeAppHosts"
           AfterTargets="Publish"
-          Condition="('$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'true' or '$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'True') and ('$(PowerShellSDKRuntimeNativeAppHostCopyToPublish)' == 'true' or '$(PowerShellSDKRuntimeNativeAppHostCopyToPublish)' == 'True')">
+          Condition="'$(_PowerShellSDKRuntimeNativeCopyToPublishEnabled)' == 'true'">
     <ItemGroup>
       <_PowerShellSDKAutomaticSharedPublishPayloadFile Include="$(PublishDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/*.dll;$(PublishDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/*.xml;$(PublishDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/*.config" />
       <_PowerShellSDKRuntimeNativeSharedPublishDependencySourceFile Include="$(PublishDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadRid)/lib/**/*.dll" />
@@ -678,7 +687,7 @@
 
   <Target Name="PowerShellSDKRewriteSelfContainedPublishedRuntimeConfig"
           AfterTargets="Publish"
-          Condition="('$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True' or '$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'true' or '$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'True') and ('$(SelfContained)' == 'true' or '$(SelfContained)' == 'True')">
+          Condition="'$(_PowerShellSDKCopyToPublishEnabled)' == 'true' and '$(_PowerShellSDKAppHostEnabled)' == 'true' and '$(_PowerShellSDKSelfContainedValue)' == 'true'">
     <PowerShellSDKRewriteSelfContainedRuntimeConfig
       RuntimeConfigPath="$(PublishDir)pwsh.runtimeconfig.json"
       ApplicationRuntimeConfigPath="$(PublishDir)$(AssemblyName).runtimeconfig.json" />
@@ -686,7 +695,7 @@
 
   <Target Name="PowerShellSDKRewriteSelfContainedPublishedRuntimeNativeRuntimeConfigs"
           AfterTargets="Publish"
-          Condition="('$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'true' or '$(PowerShellSDKIncludeRuntimeNativeAppHosts)' == 'True') and ('$(SelfContained)' == 'true' or '$(SelfContained)' == 'True')">
+          Condition="'$(_PowerShellSDKRuntimeNativeCopyToPublishEnabled)' == 'true' and '$(_PowerShellSDKSelfContainedValue)' == 'true'">
     <PowerShellSDKRewriteSelfContainedRuntimeConfig
       RuntimeConfigPath="$(PublishDir)runtimes/win-x64/native/pwsh.runtimeconfig.json"
       ApplicationRuntimeConfigPath="$(PublishDir)$(AssemblyName).runtimeconfig.json"

--- a/eng/New-PowerShellDistroArchive.ps1
+++ b/eng/New-PowerShellDistroArchive.ps1
@@ -746,7 +746,7 @@ try {
   $EscapedTargetFramework = ConvertTo-XmlAttributeValue $TargetFramework
   $EscapedRuntimeIdentifier = ConvertTo-XmlAttributeValue $RuntimeIdentifier
   $EscapedHostBaseName = ConvertTo-XmlAttributeValue $HostBaseName
-  $EscapedGenerateConfig = if ($RuntimeIdentifier -like 'win-*') { 'true' } else { 'false' }
+  $EscapedConfigMode = if ($RuntimeIdentifier -like 'win-*') { 'Copy' } else { 'None' }
 
   $ProjectXml = @"
 <Project Sdk="Microsoft.NET.Sdk">
@@ -756,10 +756,10 @@ try {
     <RuntimeIdentifier>$EscapedRuntimeIdentifier</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <AssemblyName>$EscapedHostBaseName</AssemblyName>
-    <PowerShellSDKIncludeAppHost>true</PowerShellSDKIncludeAppHost>
+    <PowerShellSDKAppHostLayout>Root</PowerShellSDKAppHostLayout>
     <PowerShellSDKAppHostRuntimeIdentifier>$EscapedRuntimeIdentifier</PowerShellSDKAppHostRuntimeIdentifier>
-    <PowerShellSDKIncludePSGalleryModules>true</PowerShellSDKIncludePSGalleryModules>
-    <PowerShellSDKGenerateConfig>$EscapedGenerateConfig</PowerShellSDKGenerateConfig>
+    <PowerShellSDKPSGalleryModules>All</PowerShellSDKPSGalleryModules>
+    <PowerShellSDKConfig>$EscapedConfigMode</PowerShellSDKConfig>
     <PowerShellSDKConfigExecutionPolicy>Bypass</PowerShellSDKConfigExecutionPolicy>
     <PowerShellSDKConfigOverwriteExisting>true</PowerShellSDKConfigOverwriteExisting>
   </PropertyGroup>
@@ -838,7 +838,7 @@ Console.WriteLine(typeof(PowerShell).Assembly.GetName().Name);
     $PublishDirectory
   )
   if (Test-Path -LiteralPath $LocalizedResourceRoot -PathType Container) {
-    $PublishArguments += '/p:PowerShellSDKIncludeLocalizedResources=true'
+    $PublishArguments += '/p:PowerShellSDKLocalizedResources=Copy'
   }
   Invoke-NativeCommand dotnet @PublishArguments
 

--- a/eng/Validate-PowerShellSdkPackage.ps1
+++ b/eng/Validate-PowerShellSdkPackage.ps1
@@ -613,7 +613,7 @@ function Invoke-RuntimeNativeOverwriteProbe {
       '-verbosity:minimal',
       "-t:$TargetName",
       "/p:RuntimeIdentifier=$CurrentRuntimeIdentifier",
-      "/p:PowerShellSDKIncludeRuntimeNativeAppHosts=true",
+      "/p:PowerShellSDKAppHostLayout=RuntimeNative",
       "/p:PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers=$RuntimeIdentifiersPropertyValue"
     )
     if ($PublishDirectory) {
@@ -1161,7 +1161,7 @@ foreach (PSObject result in ps.Invoke())
     Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'TargetFramework' -Value $SampleTargetFramework
   }
   Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'RuntimeIdentifier' -Value $RuntimeIdentifier
-  Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'PowerShellSDKIncludeRuntimeNativeAppHosts' -Value 'true'
+  Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'PowerShellSDKAppHostLayout' -Value 'RuntimeNative'
   Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers' -Value ($RuntimeNativeValidationRids -join ';')
   Add-RuntimeNativePublishDuplicateProbeTarget -Project $Project -PackageId $PackageId -PackageVersion $NormalizedPackageVersion -RuntimeIdentifiers $RuntimeNativeValidationRids
   if ($RuntimeAssetGroup -eq 'win') {
@@ -1257,7 +1257,7 @@ foreach (PSObject result in ps.Invoke())
     '-nologo',
     '-verbosity:minimal',
     '-t:PowerShellSDKCopyRuntimeNativeLocalizedResourcesToOutput',
-    '/p:PowerShellSDKIncludeLocalizedResources=true'
+    '/p:PowerShellSDKLocalizedResources=Copy'
   )
   Assert-LocalizedResourcePresent -Directory $OutputDirectory -RelativePath $RepresentativeLocalizedResourcePath -Description 'Sample app output with localized resources opt-in'
   Assert-FileContentMatches -ExpectedPath $RepresentativeLocalizedResourcePackagePath -ActualPath $OutputLocalizedResourcePath -Description 'Sample app output localized resource opt-in'
@@ -1308,7 +1308,7 @@ foreach (PSObject result in ps.Invoke())
     }
   }
 
-  $PSGallerySubsetModuleNamesPropertyValue = $PSGallerySubsetModuleNames -join ';'
+  $PSGallerySubsetModuleNamesPropertyValue = $PSGallerySubsetModuleNames -join '%3B'
   $UnexpectedPSGallerySubsetModuleNames = @($PSGalleryModulePackageIds | Where-Object { $PSGallerySubsetModuleNames -notcontains $_ })
   Invoke-DotNet @(
     'msbuild',
@@ -1316,8 +1316,7 @@ foreach (PSObject result in ps.Invoke())
     '-nologo',
     '-verbosity:minimal',
     '-t:PowerShellSDKCopyPSGalleryModulesToOutput',
-    "/p:PowerShellSDKIncludePSGalleryModules=true",
-    "/p:PowerShellSDKPSGalleryModuleNames=$PSGallerySubsetModuleNamesPropertyValue"
+    "/p:PowerShellSDKPSGalleryModules=$PSGallerySubsetModuleNamesPropertyValue"
   )
   Assert-PSGalleryModulesPresent -Directory $OutputDirectory -ModuleNames $PSGallerySubsetModuleNames -Description 'Sample app output with PSGallery subset opt-in'
   Assert-PSGalleryModulesAbsent -Directory $OutputDirectory -ModuleNames $UnexpectedPSGallerySubsetModuleNames -Description 'Sample app output with PSGallery subset opt-in'
@@ -1328,7 +1327,7 @@ foreach (PSObject result in ps.Invoke())
     '-nologo',
     '-verbosity:minimal',
     '-t:PowerShellSDKCopyPSGalleryModulesToOutput',
-    "/p:PowerShellSDKIncludePSGalleryModules=true"
+    "/p:PowerShellSDKPSGalleryModules=All"
   )
   Assert-PSGalleryModulesPresent -Directory $OutputDirectory -ModuleNames $PSGalleryProbeModuleNames -Description 'Sample app output with PSGallery opt-in'
   $OutputRuntimeNativePwshPath = Join-Path $OutputDirectory "runtimes/$RuntimeIdentifier/native/$ExecutableName"
@@ -1350,8 +1349,7 @@ foreach (PSObject result in ps.Invoke())
     'false',
     '-o',
     $PSGalleryPublishDirectory,
-    "/p:PowerShellSDKIncludePSGalleryModules=true",
-    "/p:PowerShellSDKPSGalleryModuleNames=$PSGallerySubsetModuleNamesPropertyValue"
+    "/p:PowerShellSDKPSGalleryModules=$PSGallerySubsetModuleNamesPropertyValue"
   )
   Assert-SharedPowerShellOutput -Directory $PSGalleryPublishDirectory -SelfContained $false -Description 'Sample PSGallery publish output'
   Assert-PowerShellConfig -Directory $PSGalleryPublishDirectory -ExpectedExecutionPolicy 'Bypass' -Description 'Sample PSGallery publish output'
@@ -1378,7 +1376,7 @@ foreach (PSObject result in ps.Invoke())
     'false',
     '-o',
     $LocalizedPublishDirectory,
-    '/p:PowerShellSDKIncludeLocalizedResources=true'
+    '/p:PowerShellSDKLocalizedResources=Copy'
   )
   Assert-SharedPowerShellOutput -Directory $LocalizedPublishDirectory -SelfContained $false -Description 'Sample localized resource publish output'
   Assert-LocalizedResourcePresent -Directory $LocalizedPublishDirectory -RelativePath $RepresentativeLocalizedResourcePath -Description 'Sample localized resource publish output'


### PR DESCRIPTION
## Summary
- Replace legacy per-feature copy toggles with layout/implementation/phase-oriented SDK options
- Add fail-fast validation for invalid options and unsupported runtime-native RIDs
- Update package validation, distro archive generation, and README docs for the new public option model

## Validation
- XML parse and MSBuild option/RID smoke checks
- Fake-package root, runtime-native, PSGallery, and SelfContained=True rewrite smoke checks
- `git diff --check`
- `pwsh .\.agents\skills\powershell-sdk-package-validate\scripts\Build-AndValidateLocalPowerShellSdk.ps1 -SkipPinAudit`