### PR TITLE
Add reusable source-built .NET runtime support for PowerShell CLI

### DIFF
--- a/.github/workflows/dotnet-runtime.yml
+++ b/.github/workflows/dotnet-runtime.yml
@@ -1,16 +1,23 @@
 name: .NET runtime
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  workflow_call:
+    outputs:
+      workflow-run-id:
+        description: The workflow run id that produced the DotNet-Runtime-<rid> artifacts
+        value: ${{ jobs.build.outputs.workflow-run-id }}
 env:
   DOTNET_RUNTIME_VERSION: "10.0.5"
   DOTNET_RUNTIME_REF: "v10.0.5"
   CLANG_LLVM_VERSION: "22.1.4"
   CLANG_LLVM_RELEASE: "v2026.1.1"
-  VSDEVSHELL_VERSION: "2026.1.0"
-  VSDEVSHELL_REF: "9b4518e6c45a2abedbf6a05b77c9912aaef70f1e"
+  VSDEVSHELL_MODULE_NAME: "VsDevShell"
 jobs:
   build:
     name: .NET runtime [${{matrix.arch}}-${{matrix.os}}]
     runs-on: ${{matrix.runner}}
+    outputs:
+      workflow-run-id: ${{ github.run_id }}
     strategy:
       fail-fast: false
       matrix:
@@ -22,6 +29,7 @@ jobs:
             llvm-arch: x86_64
             runner: windows-2025
             llvm-platform: windows
+            rid: win-x64
           - os: windows
             arch: arm64
             runtime-arch: arm64
@@ -29,30 +37,35 @@ jobs:
             llvm-arch: x86_64
             runner: windows-2025
             llvm-platform: windows
+            rid: win-arm64
           - os: macos
             arch: x86_64
             runtime-arch: x64
             llvm-arch: x86_64
             runner: macos-15-intel
             llvm-platform: macos
+            rid: osx-x64
           - os: macos
             arch: arm64
             runtime-arch: arm64
             llvm-arch: aarch64
             runner: macos-15
             llvm-platform: macos
+            rid: osx-arm64
           - os: linux
             arch: x86_64
             runtime-arch: x64
             llvm-arch: x86_64
             runner: ubuntu-24.04
             llvm-platform: ubuntu-24.04
+            rid: linux-x64
           - os: linux
             arch: arm64
             runtime-arch: arm64
             llvm-arch: aarch64
             runner: ubuntu-24.04-arm
             llvm-platform: ubuntu-24.04
+            rid: linux-arm64
   
     steps:
       - name: Configure Windows runner
@@ -132,19 +145,18 @@ jobs:
           ref: ${{env.DOTNET_RUNTIME_REF}}
           path: dotnet-runtime
 
-      - name: Clone VsDevShell ${{env.VSDEVSHELL_VERSION}}
+      - name: Install ${{env.VSDEVSHELL_MODULE_NAME}} from PSGallery
         if: runner.os == 'Windows'
-        uses: actions/checkout@v7.0.0
-        with:
-          repository: awakecoding/VsDevShell
-          ref: ${{env.VSDEVSHELL_REF}}
-          path: VsDevShell
+        shell: pwsh
+        run: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module -Name $Env:VSDEVSHELL_MODULE_NAME -Repository PSGallery -Scope CurrentUser -Force -AllowClobber
 
       - name: Enable Windows environment
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          Import-Module "./VsDevShell/VsDevShell/VsDevShell.psd1" -Force
+          Import-Module $Env:VSDEVSHELL_MODULE_NAME -Force
           $BaselinePath = $Env:PATH
           $VsDevEnv = Get-VsDevEnv -Arch '${{matrix.vs-arch}}' -HostArch x64
 
@@ -210,8 +222,50 @@ jobs:
         working-directory: dotnet-runtime
         shell: pwsh
         run: |
-          if ($IsWindows) {
-            & $Env:BUILD_CMD -arch '${{matrix.runtime-arch}}' -c Release -ninja
-          } else {
-            & $Env:BUILD_CMD -arch '${{matrix.runtime-arch}}' -c Release -ninja
+          & $Env:BUILD_CMD -arch '${{matrix.runtime-arch}}' -c Release -ninja -pack
+
+      - name: Stage runtime pack artifacts
+        working-directory: dotnet-runtime
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $Rid = '${{matrix.rid}}'
+          $ShippingDir = Join-Path $PWD 'artifacts/packages/Release/Shipping'
+          if (-not (Test-Path -LiteralPath $ShippingDir -PathType Container)) {
+            throw "Runtime pack output directory was not found: $ShippingDir"
           }
+
+          $StageDir = Join-Path $Env:RUNNER_TEMP "dotnet-runtime-pack-$Rid"
+          Remove-Item -LiteralPath $StageDir -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -Path $StageDir -ItemType Directory -Force | Out-Null
+
+          # The runtime pack for this RID and the matching ref pack are the artifacts the
+          # CLI workflow restores to override the stock Microsoft.NETCore.App packages.
+          $Packs = @(Get-ChildItem -LiteralPath $ShippingDir -Recurse -File -Filter '*.nupkg' |
+            Where-Object {
+              $_.Name -match '^Microsoft\.NETCore\.App\.(Runtime\.' + [regex]::Escape($Rid) + '|Ref)\.' -or
+              $_.Name -match '^Microsoft\.NETCore\.App\.Runtime\.' + [regex]::Escape($Rid) + '\.'
+            })
+
+          if ($Packs.Count -eq 0) {
+            throw "No Microsoft.NETCore.App runtime/ref packs for RID '$Rid' were found under $ShippingDir"
+          }
+
+          foreach ($Pack in $Packs) {
+            Copy-Item -LiteralPath $Pack.FullName -Destination $StageDir -Force
+            Write-Host "Staged runtime pack: $($Pack.Name)"
+          }
+
+          $ManifestPath = Join-Path $StageDir 'runtime-pack-rid.txt'
+          Set-Content -LiteralPath $ManifestPath -Value $Rid -Encoding ASCII
+
+          Write-Host "##[group]Staged runtime packs"
+          Get-ChildItem -LiteralPath $StageDir -File | ForEach-Object { Write-Host "  $($_.Name)" }
+          Write-Host "##[endgroup]"
+
+      - name: Upload runtime pack
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: DotNet-Runtime-${{matrix.rid}}
+          path: ${{ runner.temp }}/dotnet-runtime-pack-${{matrix.rid}}/*.nupkg
+          if-no-files-found: error

--- a/.github/workflows/powershell-cli.yml
+++ b/.github/workflows/powershell-cli.yml
@@ -19,6 +19,15 @@ on:
         required: true
         type: boolean
         default: false
+      use_custom_dotnet_runtime:
+        description: Use a source-built .NET runtime pack (from dotnet-runtime.yml) instead of the stock runtime
+        required: false
+        type: boolean
+        default: false
+      dotnet_runtime_run_id:
+        description: Optional dotnet-runtime.yml run ID whose pack artifact should be used (blank = build in this workflow, latest = select latest successful runtime run, or a specific run ID to reuse its artifacts)
+        default: ""
+        required: false
   workflow_call:
     inputs:
       sdk_package_version:
@@ -41,6 +50,16 @@ on:
         required: false
         type: boolean
         default: false
+      use_custom_dotnet_runtime:
+        description: Use a source-built .NET runtime pack (from dotnet-runtime.yml) instead of the stock runtime
+        default: false
+        required: false
+        type: boolean
+      dotnet_runtime_run_id:
+        description: Optional dotnet-runtime.yml run ID whose pack artifact should be used (blank = build in this workflow, latest = select latest successful runtime run, or a specific run ID to reuse its artifacts)
+        default: ""
+        required: false
+        type: string
 permissions:
   actions: read
   contents: read
@@ -187,6 +206,40 @@ jobs:
           path: sdk-package-source
           github-token: ${{ github.token }}
 
+      - name: Resolve dotnet runtime workflow run
+        if: ${{ inputs.use_custom_dotnet_runtime == true }}
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $RequestedRunId = '${{ inputs.dotnet_runtime_run_id }}'.Trim()
+          if ([string]::IsNullOrWhiteSpace($RequestedRunId)) {
+            throw "use_custom_dotnet_runtime is enabled but dotnet_runtime_run_id is blank. Set it to a specific dotnet-runtime.yml run ID, or 'latest' to select the latest successful runtime run."
+          }
+
+          $ResolvedRunId = $RequestedRunId
+          if ($RequestedRunId -eq 'latest') {
+            $Runs = gh run list -R $Env:GITHUB_REPOSITORY -w '.NET runtime' --json databaseId,status,conclusion 2>$null | ConvertFrom-Json
+            $ResolvedRunId = @($Runs | Where-Object { $_.status -eq 'completed' -and $_.conclusion -eq 'success' } | Select-Object -First 1 -ExpandProperty databaseId)
+            if (-not $ResolvedRunId) {
+              throw "No successful '.NET runtime' workflow runs were found to reuse."
+            }
+          }
+
+          "DOTNET_RUNTIME_RUN_ID=$ResolvedRunId" | Out-File -FilePath $Env:GITHUB_ENV -Append
+          Write-Host "Resolved dotnet-runtime workflow run: $ResolvedRunId"
+
+      - name: Download source-built .NET runtime pack
+        if: ${{ inputs.use_custom_dotnet_runtime == true }}
+        uses: actions/download-artifact@v8.0.1
+        with:
+          run-id: ${{ env.DOTNET_RUNTIME_RUN_ID }}
+          name: DotNet-Runtime-${{matrix.rid}}
+          path: custom-runtime-source
+          github-token: ${{ github.token }}
+
       - name: Package PowerShell distro from SDK
         shell: pwsh
         run: |
@@ -232,6 +285,28 @@ jobs:
           }
           if ('${{ inputs.ready_to_run }}' -eq 'true') {
             $PackageArguments.ReadyToRun = $true
+          }
+          $UseCustomRuntime = '${{ inputs.use_custom_dotnet_runtime }}' -ieq 'true'
+          if ($UseCustomRuntime) {
+            $CustomRuntimeSource = Join-Path $PWD 'custom-runtime-source'
+            $RuntimePackNamePattern = '^Microsoft\.NETCore\.App\.Runtime\.' + [regex]::Escape('${{matrix.rid}}') + '\.(?<version>.+)\.nupkg$'
+            $RuntimePacks = @(Get-ChildItem -LiteralPath $CustomRuntimeSource -Filter 'Microsoft.NETCore.App.Runtime.*.nupkg' -File | Where-Object {
+              $_.Name -match $RuntimePackNamePattern -and $_.Name -notmatch '\.symbols\.nupkg$'
+            })
+            if ($RuntimePacks.Count -eq 0) {
+              throw "use_custom_dotnet_runtime is enabled but no Microsoft.NETCore.App.Runtime.*.nupkg was found in $CustomRuntimeSource."
+            }
+
+            $RuntimePack = $RuntimePacks | Select-Object -First 1
+            $RuntimeVersion = [regex]::Match($RuntimePack.Name, $RuntimePackNamePattern).Groups['version'].Value
+            if ([string]::IsNullOrWhiteSpace($RuntimeVersion)) {
+              throw "Could not determine runtime pack version from filename: $($RuntimePack.Name)"
+            }
+
+            Write-Host "Discovered custom runtime pack: $($RuntimePack.Name)"
+            Write-Host "Using source-built .NET runtime: $CustomRuntimeSource (version $RuntimeVersion)"
+            $PackageArguments.CustomRuntimeSource = $CustomRuntimeSource
+            $PackageArguments.CustomRuntimePackageVersion = $RuntimeVersion
           }
 
           & $PackageScript @PackageArguments

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,15 @@ on:
       ready_to_run:
         description: Apply ReadyToRun optimization to CLI archives and sign final R2R payloads when signing is enabled
         required: true
+      use_custom_dotnet_runtime:
+        description: Build the CLI against a source-built .NET runtime (runs dotnet-runtime.yml first unless dotnet_runtime_run_id is provided)
+        required: false
         type: boolean
         default: false
+      dotnet_runtime_run_id:
+        description: Optional dotnet-runtime.yml run ID to reuse; leave blank to build in this workflow, or set latest to select the latest successful runtime run
+        required: false
+        default: ""
 
 permissions:
   actions: read
@@ -60,9 +67,19 @@ jobs:
       sign-dry-run: ${{ inputs.sign-dry-run }}
     secrets: inherit
 
+  dotnet-runtime:
+    name: Build source .NET runtime
+    if: ${{ inputs.use_custom_dotnet_runtime == true && inputs.dotnet_runtime_run_id == '' }}
+    uses: ./.github/workflows/dotnet-runtime.yml
+    permissions:
+      actions: read
+      contents: read
+    secrets: inherit
+
   cli:
     name: Build PowerShell CLI
-    needs: sdk
+    needs: [sdk, dotnet-runtime]
+    if: ${{ always() && needs.sdk.result == 'success' }}
     uses: ./.github/workflows/powershell-cli.yml
     permissions:
       actions: read
@@ -71,13 +88,15 @@ jobs:
       sdk_package_version: ${{ needs.sdk.outputs.sdk-package-version }}
       sdk_artifact_name: ${{ needs.sdk.outputs.release-sdk-package-artifact }}
       ready_to_run: ${{ inputs.ready_to_run }}
+      use_custom_dotnet_runtime: ${{ inputs.use_custom_dotnet_runtime }}
+      dotnet_runtime_run_id: ${{ inputs.dotnet_runtime_run_id || needs.dotnet-runtime.outputs.workflow-run-id }}
     secrets: inherit
 
   publish:
     name: Publish PowerShell release
     runs-on: ubuntu-24.04
-    needs: [sdk, cli]
-    if: ${{ fromJSON(needs.sdk.outputs.skip-publish) == false }}
+    needs: [sdk, cli, dotnet-runtime]
+    if: ${{ always() && fromJSON(needs.sdk.outputs.skip-publish) == false && needs.cli.result == 'success' }}
     environment: ${{ needs.sdk.outputs.package-env }}
     permissions:
       actions: read

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The local script writes under `output\local-sdk\<rid>\` and produces a single-RI
 | .NET runtime workflow | `v10.0.5` |
 | llvm-prebuilt | `v2026.1.1` |
 | clang+llvm | `22.1.4` |
-| VsDevShell | `2026.1.0` / `9b4518e6c45a2abedbf6a05b77c9912aaef70f1e` |
+| VsDevShell | `latest from PSGallery` |
 
 ## Workflows
 
@@ -48,7 +48,7 @@ The local script writes under `output\local-sdk\<rid>\` and produces a single-RI
 | `.github/workflows/powershell-sdk.yml` | Builds PowerShell from source, vendors the source-built PowerShell SDK assemblies into one `Devolutions.PowerShell.SDK` package, signs the source-built payloads, and validates it in a sample .NET app with opt-in apphost import. It can run manually or as a reusable workflow. | `PowerShell-SDK-Release-7.6.3.0` artifact containing one `.nupkg`. |
 | `.github/workflows/powershell-cli.yml` | Restores a pinned or workflow-built `Devolutions.PowerShell.SDK` package, imports its apphost and module payload through MSBuild, publishes a self-contained PowerShell layout, and repackages it for Windows, macOS, and Linux on x64 and arm64. It can run manually or as a reusable workflow. | `PowerShell-7.6.3-<os>-<arch>` `.tar.gz` artifacts. |
 | `.github/workflows/release.yml` | Orchestrates the reusable SDK workflow first, repackages that signed SDK artifact through the reusable CLI workflow, publishes the SDK package, and creates the GitHub release. | NuGet.org publish plus GitHub release `v7.6.3.0` containing the SDK `.nupkg`, all CLI `.tar.gz` archives, and checksums. |
-| `.github/workflows/dotnet-runtime.yml` | Builds the .NET runtime tag used by this PowerShell release for Windows, macOS, and Linux on x86_64 and arm64 with prebuilt clang+llvm from `awakecoding/llvm-prebuilt`. | Runtime build output in the workflow logs/workspace. |
+| `.github/workflows/dotnet-runtime.yml` | Builds the .NET runtime tag used by this PowerShell release for Windows, macOS, and Linux on x86_64 and arm64 with prebuilt clang+llvm from `awakecoding/llvm-prebuilt`. It can run manually or as a reusable workflow and uploads a `DotNet-Runtime-<rid>` artifact per matrix entry containing the source-built `Microsoft.NETCore.App.Runtime.<rid>` runtime pack. | `DotNet-Runtime-<rid>` artifacts containing the source-built runtime packs. |
 
 All workflows are manual and can be started from the GitHub Actions **Run workflow** button.
 
@@ -66,6 +66,8 @@ Manual inputs:
 | `dry-run` | Simulates publishing. This defaults to `true`; non-production environments are forced to dry-run when publishing is requested. |
 | `sign-dry-run` | Signs the package during a dry-run when code signing secrets are available. This defaults to `false` so dry-runs can exercise packaging and release flow without requiring signing credentials. |
 | `ready_to_run` | Applies ReadyToRun optimization to CLI archives. When SDK code signing is enabled, the release workflow signs and verifies the final post-R2R CLI archive payloads before checksums and release creation. |
+| `use_custom_dotnet_runtime` | Optional. When enabled, repackages the CLI archives against a source-built .NET runtime instead of the stock `Microsoft.NETCore.App.Runtime.<rid>` pack from NuGet.org. If `dotnet_runtime_run_id` is blank, the release workflow builds `.github/workflows/dotnet-runtime.yml` first; set it to a specific run ID or `latest` to reuse a prior successful runtime run. Defaults to `false`, so releases use the stock runtime unless this is explicitly turned on. |
+| `dotnet_runtime_run_id` | Optional. Reuse a prior successful `.NET runtime` workflow run instead of building one in the current release chain. Leave blank to build in the current workflow, or pass a specific run ID or `latest` to select the newest successful runtime run. |
 
 The standalone CLI workflow also has an opt-in `ready_to_run` input that runs a targeted crossgen2 pass over packaged PowerShell managed assemblies after the self-contained layout is assembled. It is disabled by default because ReadyToRun rewrites managed PE files and invalidates existing Authenticode signatures. For signed releases, use `.github/workflows/release.yml` with both signing and `ready_to_run` enabled so the CLI archives are signed after the R2R pass.
 
@@ -82,7 +84,17 @@ Before validation and CLI packaging, the SDK workflow runs a signing stage that 
 
 Publishing uses the same NuGet.org OIDC pattern as `Devolutions/gsudo-distro`: repository environments named `publish-test` and `publish-prod`, `NuGet/login@v1`, and a `NUGET_BOT_USERNAME` secret available to the publishing environment. The release workflow grants `id-token: write` for NuGet OIDC and `contents: write` for GitHub release creation only in the publishing job. A real publish pushes the validated `.nupkg` containing signed Windows payloads to `https://api.nuget.org/v3/index.json` and creates a GitHub release named `Devolutions.PowerShell.SDK vX.Y.Z.R` with tag `vX.Y.Z.R`, release notes, the SDK package asset, every CLI archive, and a SHA256 checksum file covering all release assets.
 
-## Branching model
+## Source-built .NET runtime option
+
+By default, `powershell-cli.yml` repackages the `Devolutions.PowerShell.SDK` nupkg into self-contained archives using the stock `Microsoft.NETCore.App.Runtime.<rid>` pack restored from NuGet.org. For a fully from-source PowerShell distribution, the CLI workflow can instead consume the .NET runtime produced by `dotnet-runtime.yml`.
+
+This is **off by default** and does not change existing behavior when unused. To enable it:
+
+- In `powershell-cli.yml` (manual or reusable), set `use_custom_dotnet_runtime` to `true` and provide `dotnet_runtime_run_id` pointing at a completed `dotnet-runtime.yml` run, or set it to `latest` to auto-pick the newest successful `.NET runtime` run. The CLI job for each RID downloads the matching `DotNet-Runtime-<rid>` artifact, stages it as a local NuGet folder feed, and repoints the self-contained restore/publish at that feed with `/p:RuntimeFrameworkVersion=<version>`.
+- In `release.yml`, set `use_custom_dotnet_runtime` to `true`. If `dotnet_runtime_run_id` is blank, the release workflow runs `dotnet-runtime.yml` first; otherwise it skips the build and forwards the supplied run ID (including `latest`) to the reusable CLI job so the whole chain produces CLI archives built from the custom runtime.
+
+`eng/New-PowerShellDistroArchive.ps1` accepts optional `-CustomRuntimeSource` and `-CustomRuntimePackageVersion` parameters that inject the local runtime feed (with `packageSourceMapping` patterns for `Microsoft.NETCore.App.*`) ahead of NuGet.org and pin the runtime pack version during restore and publish. When the parameters are omitted, the generated `nuget.config` and publish command are identical to the stock path.
+
 
 This repository follows a downstream patch branch model inspired by `Devolutions/gsudo-distro`: `master` stays downstream-only, upstream PowerShell refs are mirrored under `upstream/*`, and source patches live on `downstream/vX.Y.Z` branches based on upstream release tags. The patched source is exposed on `master` as a same-repo submodule at `pwsh-src/` pinned to a commit on `downstream/vX.Y.Z`, so workflows build the exact reviewed source tree with a single `actions/checkout` using `submodules: true`. See [BRANCHING.md](BRANCHING.md) for the full branch, tag, submodule, and worktree flow.
 

--- a/eng/New-PowerShellDistroArchive.ps1
+++ b/eng/New-PowerShellDistroArchive.ps1
@@ -26,7 +26,11 @@ param(
 
   [switch] $ReadyToRunUseCache,
 
-  [string] $ReadyToRunCachePath
+  [string] $ReadyToRunCachePath,
+
+  [string] $CustomRuntimeSource,
+
+  [string] $CustomRuntimePackageVersion
 )
 
 Set-StrictMode -Version 3.0
@@ -58,6 +62,80 @@ function ConvertTo-XmlAttributeValue {
   }
 
   return [System.Security.SecurityElement]::Escape($Value)
+}
+
+function Get-EffectiveCustomRuntimePackageVersion {
+  param(
+    [Parameter(Mandatory)]
+    [string] $PackageVersion
+  )
+
+  if ($PackageVersion -match '^(?<stable>\d+(?:\.\d+)+)-') {
+    return $Matches['stable']
+  }
+
+  return $PackageVersion
+}
+
+function New-CustomRuntimeFeed {
+  param(
+    [Parameter(Mandatory)]
+    [string] $SourceRoot,
+
+    [Parameter(Mandatory)]
+    [string] $DestinationRoot,
+
+    [Parameter(Mandatory)]
+    [string] $RuntimeIdentifier,
+
+    [Parameter(Mandatory)]
+    [string] $PackageVersion,
+
+    [Parameter(Mandatory)]
+    [string] $EffectivePackageVersion
+  )
+
+  $SourceRootPath = (Resolve-Path -LiteralPath $SourceRoot).Path
+  Remove-Item -LiteralPath $DestinationRoot -Recurse -Force -ErrorAction SilentlyContinue
+  New-Item -Path $DestinationRoot -ItemType Directory -Force | Out-Null
+
+  $RuntimePackPattern = '^Microsoft\.NETCore\.App\.(Ref|Runtime\.' + [regex]::Escape($RuntimeIdentifier) + ')\.' + [regex]::Escape($PackageVersion) + '\.nupkg$'
+  $RuntimePacks = @(Get-ChildItem -LiteralPath $SourceRootPath -Filter '*.nupkg' -File | Where-Object {
+    $_.Name -match $RuntimePackPattern -and $_.Name -notmatch '\.symbols\.nupkg$'
+  })
+  if ($RuntimePacks.Count -eq 0) {
+    throw "No runtime/ref packages matching version '$PackageVersion' for RID '$RuntimeIdentifier' were found in $SourceRootPath"
+  }
+
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+  foreach ($RuntimePack in $RuntimePacks) {
+    if ($EffectivePackageVersion -eq $PackageVersion) {
+      Copy-Item -LiteralPath $RuntimePack.FullName -Destination $DestinationRoot -Force
+      continue
+    }
+
+    $PackageExtractRoot = Join-Path $DestinationRoot ([System.IO.Path]::GetFileNameWithoutExtension($RuntimePack.Name))
+    Remove-Item -LiteralPath $PackageExtractRoot -Recurse -Force -ErrorAction SilentlyContinue
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($RuntimePack.FullName, $PackageExtractRoot)
+
+    $NuspecPath = Get-ChildItem -LiteralPath $PackageExtractRoot -Filter '*.nuspec' -File | Select-Object -First 1 -ExpandProperty FullName
+    if (-not $NuspecPath) {
+      throw "Could not find a nuspec inside custom runtime package: $($RuntimePack.FullName)"
+    }
+
+    $NuspecContent = Get-Content -LiteralPath $NuspecPath -Raw
+    $UpdatedNuspecContent = $NuspecContent -replace '<version>[^<]+</version>', "<version>$EffectivePackageVersion</version>"
+    Set-Content -LiteralPath $NuspecPath -Value $UpdatedNuspecContent -Encoding utf8
+
+    $RepackedName = $RuntimePack.Name -replace [regex]::Escape(".$PackageVersion.nupkg"), ".$EffectivePackageVersion.nupkg"
+    $RepackedPath = Join-Path $DestinationRoot $RepackedName
+    Remove-Item -LiteralPath $RepackedPath -Force -ErrorAction SilentlyContinue
+    [System.IO.Compression.ZipFile]::CreateFromDirectory($PackageExtractRoot, $RepackedPath)
+    Remove-Item -LiteralPath $PackageExtractRoot -Recurse -Force
+  }
+
+  return (Resolve-Path -LiteralPath $DestinationRoot).Path
 }
 
 function Get-PowerShellTargetFramework {
@@ -779,8 +857,63 @@ Console.WriteLine(typeof(PowerShell).Assembly.GetName().Name);
 
   $NuGetOrgSource = 'https://api.nuget.org/v3/index.json'
   $PackageSourceMatchesNuGetOrg = $PackageSource.TrimEnd('/') -eq $NuGetOrgSource.TrimEnd('/')
+
+  # When a source-built .NET runtime pack is supplied, inject a local folder feed that takes
+  # precedence over nuget.org for the Microsoft.NETCore.App ref/runtime packs for this RID.
+  # Combined with the stable RuntimeFrameworkVersion passed to restore/publish below, this makes
+  # the self-contained publish consume the custom runtime pack without hijacking unrelated host
+  # or AspNetCore runtime packs from nuget.org. When the source-built pack version is prerelease
+  # (for example 10.0.4-dev), repack it locally as the corresponding stable patch version solely
+  # for restore so the SDK can still resolve the stable host/framework packs it needs.
+  $UseCustomRuntime = -not [string]::IsNullOrWhiteSpace($CustomRuntimeSource)
+  $EffectiveCustomRuntimeSource = $null
+  $EffectiveCustomRuntimePackageVersion = $null
+  if ($UseCustomRuntime) {
+    $EffectiveCustomRuntimePackageVersion = Get-EffectiveCustomRuntimePackageVersion -PackageVersion $CustomRuntimePackageVersion
+    $EffectiveCustomRuntimeSource = New-CustomRuntimeFeed `
+      -SourceRoot $CustomRuntimeSource `
+      -DestinationRoot (Join-Path $WorkRoot 'custom-runtime-feed') `
+      -RuntimeIdentifier $RuntimeIdentifier `
+      -PackageVersion $CustomRuntimePackageVersion `
+      -EffectivePackageVersion $EffectiveCustomRuntimePackageVersion
+    $CustomRuntimeSourcePath = (Resolve-Path -LiteralPath $EffectiveCustomRuntimeSource).Path
+    $EscapedCustomRuntimeSource = ConvertTo-XmlAttributeValue $CustomRuntimeSourcePath
+    $CustomRuntimeSourceLine = "    <add key=`"custom-runtime`" value=`"$EscapedCustomRuntimeSource`" />"
+    $CustomRuntimeMappingBlock = @"
+    <packageSource key="custom-runtime">
+      <package pattern="Microsoft.NETCore.App.Ref" />
+      <package pattern="Microsoft.NETCore.App.Runtime.$EscapedRuntimeIdentifier" />
+    </packageSource>
+"@
+    if ($EffectiveCustomRuntimePackageVersion -ne $CustomRuntimePackageVersion) {
+      Write-Host "Normalizing custom runtime restore version from $CustomRuntimePackageVersion to $EffectiveCustomRuntimePackageVersion"
+    }
+  } else {
+    $CustomRuntimeSourceLine = $null
+    $CustomRuntimeMappingBlock = $null
+  }
+
   if ($PackageSourceMatchesNuGetOrg) {
-    $NuGetConfig = @"
+    if ($UseCustomRuntime) {
+      $NuGetConfig = @"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    $CustomRuntimeSourceLine
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+$CustomRuntimeMappingBlock
+    <packageSource key="nuget.org">
+      <package pattern="$EscapedPackageId" />
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>
+"@
+    } else {
+      $NuGetConfig = @"
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
@@ -795,8 +928,31 @@ Console.WriteLine(typeof(PowerShell).Assembly.GetName().Name);
   </packageSourceMapping>
 </configuration>
 "@
+    }
   } else {
-    $NuGetConfig = @"
+    if ($UseCustomRuntime) {
+      $NuGetConfig = @"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    $CustomRuntimeSourceLine
+    <add key="powershell-sdk" value="$EscapedPackageSource" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+$CustomRuntimeMappingBlock
+    <packageSource key="powershell-sdk">
+      <package pattern="$EscapedPackageId" />
+    </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>
+"@
+    } else {
+      $NuGetConfig = @"
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
@@ -814,10 +970,15 @@ Console.WriteLine(typeof(PowerShell).Assembly.GetName().Name);
   </packageSourceMapping>
 </configuration>
 "@
+    }
   }
   Set-Content -LiteralPath $NuGetConfigPath -Value $NuGetConfig -Encoding utf8
 
-  Invoke-NativeCommand dotnet @('restore', $ProjectPath, '--configfile', $NuGetConfigPath, '--verbosity', 'minimal', '-r', $RuntimeIdentifier, '/p:SelfContained=true')
+  $RestoreArguments = @('restore', $ProjectPath, '--configfile', $NuGetConfigPath, '--verbosity', 'minimal', '-r', $RuntimeIdentifier, '/p:SelfContained=true')
+  if ($UseCustomRuntime) {
+    $RestoreArguments += "/p:RuntimeFrameworkVersion=$EffectiveCustomRuntimePackageVersion"
+  }
+  Invoke-NativeCommand dotnet @RestoreArguments
   $PackageRoot = Get-RestoredSdkPackageRoot -PackagesDirectory $PackagesDirectory -PackageId $PackageId -PackageVersion $PackageVersion
   $RuntimeGroup = Get-PackageRuntimeGroup -Rid $RuntimeIdentifier
   $LocalizedResourceRoot = Join-Path $PackageRoot "buildTransitive\localized-resources\$RuntimeGroup\lib\$TargetFramework"
@@ -837,6 +998,9 @@ Console.WriteLine(typeof(PowerShell).Assembly.GetName().Name);
     '-o',
     $PublishDirectory
   )
+  if ($UseCustomRuntime) {
+    $PublishArguments += "/p:RuntimeFrameworkVersion=$EffectiveCustomRuntimePackageVersion"
+  }
   if (Test-Path -LiteralPath $LocalizedResourceRoot -PathType Container) {
     $PublishArguments += '/p:PowerShellSDKLocalizedResources=Copy'
   }


### PR DESCRIPTION
## Summary
- install the latest PSGallery `VsDevShell` module instead of pinning a checkout commit in `dotnet-runtime.yml`
- add an opt-in path for `powershell-cli.yml` and `release.yml` to consume a source-built .NET runtime from `dotnet-runtime.yml`
- support reusing runtime artifacts from a specific prior run ID or the latest successful runtime run for faster iteration
- stage a normalized local custom-runtime feed in `New-PowerShellDistroArchive.ps1` so self-contained CLI publish can consume the source-built runtime while leaving unrelated packs on nuget.org
- document the new runtime workflow behavior and reuse inputs in `README.md`

## Validation
- successful source-built runtime artifact run: `28677605871`
- successful end-to-end dry-run reusing those artifacts: `28681327872`