### PR TITLE
Update multi-pwsh apphost package

### DIFF
--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -112,7 +112,7 @@ env:
   SDK_PACKAGE_ID: "Devolutions.PowerShell.SDK"
   SDK_PACKAGE_REVISION: "0"
   MULTI_PWSH_APPHOST_PACKAGE_ID: "Devolutions.MultiPwsh.Cli"
-  MULTI_PWSH_APPHOST_PACKAGE_VERSION: "0.14.0"
+  MULTI_PWSH_APPHOST_PACKAGE_VERSION: "0.14.1"
   MULTI_PWSH_APPHOST_PACKAGE_SOURCE: "https://api.nuget.org/v3/index.json"
   PSIGN_TOOL_PACKAGE_ID: "Devolutions.Psign.Tool"
 jobs:
@@ -620,78 +620,6 @@ jobs:
             return ,$ResolvedAssets
           }
 
-          function Get-DotNetSdkBasePath {
-            $DotNetInfo = & dotnet --info
-            if ($LASTEXITCODE -ne 0) {
-              throw "dotnet --info failed with exit code $LASTEXITCODE"
-            }
-
-            $BasePathLine = $DotNetInfo | Where-Object { $_ -match '^\s*Base Path:\s*(.+)$' } | Select-Object -First 1
-            if (-not $BasePathLine -or $BasePathLine -notmatch '^\s*Base Path:\s*(.+)$') {
-              throw 'Unable to determine .NET SDK base path from dotnet --info.'
-            }
-
-            return $Matches[1].Trim()
-          }
-
-          function Get-DotNetAppHostTemplate {
-            param(
-              [Parameter(Mandatory)]
-              [string] $Rid
-            )
-
-            $SdkBasePath = Get-DotNetSdkBasePath
-            $DotNetRoot = Split-Path (Split-Path $SdkBasePath -Parent) -Parent
-            $HostPackRoot = Join-Path $DotNetRoot "packs/Microsoft.NETCore.App.Host.$Rid"
-            if (-not (Test-Path $HostPackRoot -PathType Container)) {
-              throw "The .NET SDK host pack for '$Rid' was not found at $HostPackRoot"
-            }
-
-            $TemplateName = if ($Rid -like 'win-*') { 'apphost.exe' } else { 'apphost' }
-            $Template = Get-ChildItem -LiteralPath $HostPackRoot -Recurse -Filter $TemplateName |
-              Sort-Object FullName |
-              Select-Object -Last 1
-            if (-not $Template) {
-              throw "The .NET SDK host pack for '$Rid' does not contain $TemplateName"
-            }
-
-            return $Template.FullName
-          }
-
-          function New-SharedPayloadAppHost {
-            param(
-              [Parameter(Mandatory)]
-              [string] $Rid,
-
-              [Parameter(Mandatory)]
-              [string] $DestinationPath,
-
-              [Parameter(Mandatory)]
-              [string] $ResourceAssemblyPath
-            )
-
-            $SdkBasePath = Get-DotNetSdkBasePath
-            $HostModelPath = Join-Path $SdkBasePath 'Microsoft.NET.HostModel.dll'
-            if (-not (Test-Path $HostModelPath -PathType Leaf)) {
-              throw "Microsoft.NET.HostModel.dll was not found in the .NET SDK: $HostModelPath"
-            }
-
-            if (-not ([System.Management.Automation.PSTypeName]'Microsoft.NET.HostModel.AppHost.HostWriter').Type) {
-              Add-Type -Path $HostModelPath
-            }
-            $TemplatePath = Get-DotNetAppHostTemplate -Rid $Rid
-            New-Item (Split-Path $DestinationPath -Parent) -ItemType Directory -Force | Out-Null
-            [Microsoft.NET.HostModel.AppHost.HostWriter]::CreateAppHost(
-              $TemplatePath,
-              $DestinationPath,
-              '../../../pwsh.dll',
-              $false,
-              $ResourceAssemblyPath,
-              $false,
-              $false,
-              $null)
-          }
-
           $Rid = "${{matrix.rid}}"
           $OutputPath = Join-Path $PWD "PowerShell-AppHost-$Rid"
           $PSBuildParams = @{
@@ -766,8 +694,9 @@ jobs:
           Copy-Item -LiteralPath $PwshXmlPath -Destination (Join-Path $DistroPayloadStagePath 'pwsh.xml') -Force
 
           $RuntimeNativeStagePath = Join-Path $StagePath "runtime-native"
+          New-Item $RuntimeNativeStagePath -ItemType Directory -Force | Out-Null
           $RuntimeNativeAppHostPath = Join-Path $RuntimeNativeStagePath $AppHostAsset.AppHostFileName
-          New-SharedPayloadAppHost -Rid $Rid -DestinationPath $RuntimeNativeAppHostPath -ResourceAssemblyPath (Join-Path $OutputPath 'pwsh.dll')
+          Copy-Item -LiteralPath $AppHostAsset.SourcePath -Destination $RuntimeNativeAppHostPath -Force
 
           $LocalizedResourcesStagePath = Join-Path $StagePath "localized-resources"
           Get-ChildItem -LiteralPath $OutputPath -Directory |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The local script writes under `output\local-sdk\<rid>\` and produces a single-RI
 | PowerShell target framework | `net10.0` |
 | PowerShell SDK package | `Devolutions.PowerShell.SDK` / `7.6.3.0` |
 | PowerShell SDK package source | `https://api.nuget.org/v3/index.json` |
-| multi-pwsh apphost package | `Devolutions.MultiPwsh.Cli` / `0.14.0` |
+| multi-pwsh apphost package | `Devolutions.MultiPwsh.Cli` / `0.14.1` |
 | multi-pwsh apphost package source | `https://api.nuget.org/v3/index.json` |
 | psign code signing tool | `Devolutions.Psign.Tool` / `latest (un-pinned)` |
 | .NET runtime workflow | `v10.0.5` |
@@ -152,7 +152,7 @@ Use `PowerShellSDKCopyPhases` to decide where opted-in payloads are copied. The 
 | Property | Default | Values | Effect |
 | --- | --- | --- | --- |
 | `PowerShellSDKAppHostLayout` | `None` | `None`, `Root`, `RuntimeNative`, `Both` | Selects the apphost file layout. |
-| `PowerShellSDKAppHostImplementation` | `Auto` | `Auto`, `MultiPwsh`, `DotNet` | Selects the apphost executable implementation when the requested layout/package assets support it. Current package assets support `MultiPwsh` for `Root` and `DotNet` for `RuntimeNative`. |
+| `PowerShellSDKAppHostImplementation` | `Auto` | `Auto`, `MultiPwsh`, `DotNet` | Selects the apphost executable implementation when the requested layout/package assets support it. Current package assets support `MultiPwsh` for `Root` and `RuntimeNative`. |
 | `PowerShellSDKAppHostRuntimeIdentifier` | empty | RID | Overrides root apphost RID selection; otherwise `$(RuntimeIdentifier)` then `$(NETCoreSdkRuntimeIdentifier)` are used. |
 | `PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers` | empty | RID list | Semicolon-delimited runtime-native launcher RIDs; empty selects all packaged RIDs. |
 | `PowerShellSDKRuntimeNativeSharedPayloadRuntimeIdentifier` | empty | RID | Overrides the shared app-root PowerShell payload RID. Otherwise it follows `$(RuntimeIdentifier)`, `$(NETCoreSdkRuntimeIdentifier)`, then `PowerShellSDKAppHostRuntimeIdentifier`. |

--- a/eng/Microsoft.PowerShell.SDK.targets
+++ b/eng/Microsoft.PowerShell.SDK.targets
@@ -182,10 +182,8 @@
            Text="PowerShellSDKConfigOverwriteExisting must be true or false." />
     <Error Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(PowerShellSDKLocalizedResources)', '^(?i:None|Copy)$')) != 'True'"
            Text="PowerShellSDKLocalizedResources must be None or Copy." />
-    <Error Condition="'$(_PowerShellSDKRootAppHostEnabled)' == 'true' and '$(_PowerShellSDKAppHostImplementationValue)' == 'dotnet'"
-           Text="PowerShellSDKAppHostImplementation=DotNet is not available for the Root apphost layout in this SDK package." />
-    <Error Condition="'$(_PowerShellSDKRuntimeNativeAppHostEnabled)' == 'true' and '$(_PowerShellSDKAppHostImplementationValue)' == 'multipwsh'"
-           Text="PowerShellSDKAppHostImplementation=MultiPwsh is not available for the RuntimeNative apphost layout in this SDK package. Use Auto or DotNet until the package includes runtime-native multi-pwsh apphost assets." />
+    <Error Condition="'$(_PowerShellSDKAppHostEnabled)' == 'true' and '$(_PowerShellSDKAppHostImplementationValue)' == 'dotnet'"
+           Text="PowerShellSDKAppHostImplementation=DotNet is not available in this SDK package. Use Auto or MultiPwsh." />
   </Target>
 
   <Target Name="_PowerShellSDKValidateImportedOptions"

--- a/eng/Validate-PowerShellSdkPackage.ps1
+++ b/eng/Validate-PowerShellSdkPackage.ps1
@@ -1162,6 +1162,7 @@ foreach (PSObject result in ps.Invoke())
   }
   Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'RuntimeIdentifier' -Value $RuntimeIdentifier
   Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'PowerShellSDKAppHostLayout' -Value 'RuntimeNative'
+  Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'PowerShellSDKAppHostImplementation' -Value 'MultiPwsh'
   Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers' -Value ($RuntimeNativeValidationRids -join ';')
   Add-RuntimeNativePublishDuplicateProbeTarget -Project $Project -PackageId $PackageId -PackageVersion $NormalizedPackageVersion -RuntimeIdentifiers $RuntimeNativeValidationRids
   if ($RuntimeAssetGroup -eq 'win') {

--- a/scripts/Build-LocalPowerShellSdk.ps1
+++ b/scripts/Build-LocalPowerShellSdk.ps1
@@ -12,7 +12,7 @@ param(
 
   [string] $MultiPwshPackageId = 'Devolutions.MultiPwsh.Cli',
 
-  [string] $MultiPwshPackageVersion = '0.14.0',
+  [string] $MultiPwshPackageVersion = '0.14.1',
 
   [string] $MultiPwshPackageSource = 'https://api.nuget.org/v3/index.json',
 
@@ -141,78 +141,6 @@ function Get-NormalizedNuGetPackageVersion {
   }
 
   return $PackageVersion
-}
-
-function Get-DotNetSdkBasePath {
-  $DotNetInfo = & dotnet --info
-  if ($LASTEXITCODE -ne 0) {
-    throw "dotnet --info failed with exit code $LASTEXITCODE"
-  }
-
-  $BasePathLine = $DotNetInfo | Where-Object { $_ -match '^\s*Base Path:\s*(.+)$' } | Select-Object -First 1
-  if (-not $BasePathLine -or $BasePathLine -notmatch '^\s*Base Path:\s*(.+)$') {
-    throw 'Unable to determine .NET SDK base path from dotnet --info.'
-  }
-
-  return $Matches[1].Trim()
-}
-
-function Get-DotNetAppHostTemplate {
-  param(
-    [Parameter(Mandatory)]
-    [string] $Rid
-  )
-
-  $SdkBasePath = Get-DotNetSdkBasePath
-  $DotNetRoot = Split-Path (Split-Path $SdkBasePath -Parent) -Parent
-  $HostPackRoot = Join-Path $DotNetRoot "packs\Microsoft.NETCore.App.Host.$Rid"
-  if (-not (Test-Path $HostPackRoot -PathType Container)) {
-    throw "The .NET SDK host pack for '$Rid' was not found at $HostPackRoot"
-  }
-
-  $TemplateName = if ($Rid -like 'win-*') { 'apphost.exe' } else { 'apphost' }
-  $Template = Get-ChildItem -LiteralPath $HostPackRoot -Recurse -Filter $TemplateName |
-    Sort-Object FullName |
-    Select-Object -Last 1
-  if (-not $Template) {
-    throw "The .NET SDK host pack for '$Rid' does not contain $TemplateName"
-  }
-
-  return $Template.FullName
-}
-
-function New-SharedPayloadAppHost {
-  param(
-    [Parameter(Mandatory)]
-    [string] $Rid,
-
-    [Parameter(Mandatory)]
-    [string] $DestinationPath,
-
-    [Parameter(Mandatory)]
-    [string] $ResourceAssemblyPath
-  )
-
-  $SdkBasePath = Get-DotNetSdkBasePath
-  $HostModelPath = Join-Path $SdkBasePath 'Microsoft.NET.HostModel.dll'
-  if (-not (Test-Path $HostModelPath -PathType Leaf)) {
-    throw "Microsoft.NET.HostModel.dll was not found in the .NET SDK: $HostModelPath"
-  }
-
-  if (-not ([System.Management.Automation.PSTypeName]'Microsoft.NET.HostModel.AppHost.HostWriter').Type) {
-    Add-Type -Path $HostModelPath
-  }
-  $TemplatePath = Get-DotNetAppHostTemplate -Rid $Rid
-  New-Item (Split-Path $DestinationPath -Parent) -ItemType Directory -Force | Out-Null
-  [Microsoft.NET.HostModel.AppHost.HostWriter]::CreateAppHost(
-    $TemplatePath,
-    $DestinationPath,
-    '../../../pwsh.dll',
-    $false,
-    $ResourceAssemblyPath,
-    $false,
-    $false,
-    $null)
 }
 
 function ConvertTo-XmlAttributeValue {
@@ -646,7 +574,7 @@ try {
     $NativeAppHostPackageRoot = Join-Path $SdkStagePath "runtimes\$AppHostRuntimeIdentifier\native"
     New-Item $NativeAppHostPackageRoot -ItemType Directory -Force | Out-Null
     $SharedPayloadAppHostPath = Join-Path $NativeAppHostPackageRoot $AppHostAsset.AppHostFileName
-    New-SharedPayloadAppHost -Rid $AppHostRuntimeIdentifier -DestinationPath $SharedPayloadAppHostPath -ResourceAssemblyPath (Join-Path $AppHostOutputPath 'pwsh.dll')
+    Copy-Item -LiteralPath $AppHostAsset.SourcePath -Destination $SharedPayloadAppHostPath -Force
 
     foreach ($AppHostFile in @(
         @{ Name = 'pwsh.dll'; Required = $true },


### PR DESCRIPTION
## Summary
- bump Devolutions.MultiPwsh.Cli to 0.14.1 for SDK apphost packaging
- use the resolved multi-pwsh apphost for runtime-native layouts instead of generating a .NET HostWriter apphost
- allow and validate explicit `PowerShellSDKAppHostImplementation=MultiPwsh` with `RuntimeNative`

## Validation
- parsed PowerShell scripts, SDK targets XML, and `powershell-sdk.yml`
- ran `git diff --check`
- probed `Devolutions.MultiPwsh.Cli` 0.14.1 resolver metadata and confirmed both `adjacent` and `runtimeNativeSharedPayload` layouts
- ran local SDK package validation for `win-x64` with initialized `pwsh-src`