### PR TITLE
Add generalized client remoting transport extensibility

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/ConnectionFactory.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionFactory.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Management.Automation.Host;
+using System.Management.Automation.Remoting.Client;
 using System.Management.Automation.Tracing;
 
 using Microsoft.PowerShell;
@@ -454,16 +455,13 @@ namespace System.Management.Automation.Runspaces
         public static RunspacePool CreateRunspacePool(int minRunspaces,
             int maxRunspaces, RunspaceConnectionInfo connectionInfo, PSHost host, TypeTable typeTable, PSPrimitiveDictionary applicationArguments)
         {
-            if (connectionInfo is not WSManConnectionInfo &&
-                connectionInfo is not NewProcessConnectionInfo &&
-                connectionInfo is not NamedPipeConnectionInfo &&
-                connectionInfo is not VMConnectionInfo &&
-                connectionInfo is not ContainerConnectionInfo)
+            if (!ClientRemotingTransportProviderRegistry.CanCreateRunspacePoolTransport(connectionInfo))
             {
                 throw new NotSupportedException();
             }
 
-            if (connectionInfo is WSManConnectionInfo)
+            if (connectionInfo is WSManConnectionInfo &&
+                !ClientRemotingTransportProviderRegistry.WillUseRegisteredProvider(connectionInfo))
             {
                 RemotingCommandUtil.CheckHostRemotingPrerequisites();
             }
@@ -545,7 +543,8 @@ namespace System.Management.Automation.Runspaces
         /// <returns>A remote Runspace.</returns>
         public static Runspace CreateRunspace(RunspaceConnectionInfo connectionInfo, PSHost host, TypeTable typeTable, PSPrimitiveDictionary applicationArguments, string name)
         {
-            if (connectionInfo is WSManConnectionInfo)
+            if (connectionInfo is WSManConnectionInfo &&
+                !ClientRemotingTransportProviderRegistry.WillUseRegisteredProvider(connectionInfo))
             {
                 RemotingCommandUtil.CheckHostRemotingPrerequisites();
             }

--- a/src/System.Management.Automation/engine/remoting/client/ClientRemotingTransportProvider.cs
+++ b/src/System.Management.Automation/engine/remoting/client/ClientRemotingTransportProvider.cs
@@ -1,0 +1,330 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Management.Automation.Internal;
+using System.Management.Automation.Runspaces;
+using System.Management.Automation.Runspaces.Internal;
+
+namespace System.Management.Automation.Remoting.Client
+{
+    /// <summary>
+    /// Priority of remoting data made available to a custom client transport.
+    /// </summary>
+    public enum ClientRemotingDataPriority
+    {
+        /// <summary>
+        /// Default remoting data stream.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Prompt response remoting data stream.
+        /// </summary>
+        PromptResponse = 1,
+    }
+
+    /// <summary>
+    /// Context used to create a client remoting session transport.
+    /// </summary>
+    public sealed class ClientRemotingTransportCreationContext
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClientRemotingTransportCreationContext"/> class.
+        /// </summary>
+        public ClientRemotingTransportCreationContext(
+            Guid runspacePoolInstanceId,
+            string sessionName,
+            RunspaceConnectionInfo connectionInfo,
+            PSRemotingCryptoHelper cryptoHelper)
+        {
+            ArgumentNullException.ThrowIfNull(connectionInfo);
+            ArgumentNullException.ThrowIfNull(cryptoHelper);
+
+            RunspacePoolInstanceId = runspacePoolInstanceId;
+            SessionName = sessionName;
+            ConnectionInfo = connectionInfo;
+            CryptoHelper = cryptoHelper;
+        }
+
+        /// <summary>
+        /// Gets the runspace pool instance identifier.
+        /// </summary>
+        public Guid RunspacePoolInstanceId { get; }
+
+        /// <summary>
+        /// Gets the session name.
+        /// </summary>
+        public string SessionName { get; }
+
+        /// <summary>
+        /// Gets the connection information.
+        /// </summary>
+        public RunspaceConnectionInfo ConnectionInfo { get; }
+
+        /// <summary>
+        /// Gets the remoting crypto helper.
+        /// </summary>
+        public PSRemotingCryptoHelper CryptoHelper { get; }
+    }
+
+    /// <summary>
+    /// Context used to create a client remoting command transport.
+    /// </summary>
+    public sealed class ClientCommandTransportCreationContext
+    {
+        internal ClientCommandTransportCreationContext(
+            RunspaceConnectionInfo connectionInfo,
+            ClientRemotePowerShell remotePowerShell,
+            bool noInput,
+            BaseClientSessionTransportManager sessionTransportManager,
+            PSRemotingCryptoHelper cryptoHelper)
+        {
+            ArgumentNullException.ThrowIfNull(connectionInfo);
+            ArgumentNullException.ThrowIfNull(remotePowerShell);
+            ArgumentNullException.ThrowIfNull(sessionTransportManager);
+            ArgumentNullException.ThrowIfNull(cryptoHelper);
+
+            ConnectionInfo = connectionInfo;
+            RemotePowerShell = remotePowerShell;
+            NoInput = noInput;
+            SessionTransportManager = sessionTransportManager;
+            CryptoHelper = cryptoHelper;
+            RunspacePoolInstanceId = sessionTransportManager.RunspacePoolInstanceId;
+            PowerShellInstanceId = remotePowerShell.InstanceId;
+            CommandText = remotePowerShell.PowerShell.Commands.Commands.GetCommandStringForHistory();
+        }
+
+        /// <summary>
+        /// Gets the runspace pool instance identifier.
+        /// </summary>
+        public Guid RunspacePoolInstanceId { get; }
+
+        /// <summary>
+        /// Gets the PowerShell instance identifier.
+        /// </summary>
+        public Guid PowerShellInstanceId { get; }
+
+        /// <summary>
+        /// Gets the connection information.
+        /// </summary>
+        public RunspaceConnectionInfo ConnectionInfo { get; }
+
+        /// <summary>
+        /// Gets the command text used by the transport protocol for audit and authorization.
+        /// </summary>
+        public string CommandText { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the command has no input.
+        /// </summary>
+        public bool NoInput { get; }
+
+        /// <summary>
+        /// Gets the session transport manager that owns the command transport.
+        /// </summary>
+        public BaseClientSessionTransportManager SessionTransportManager { get; }
+
+        /// <summary>
+        /// Gets the remoting crypto helper.
+        /// </summary>
+        public PSRemotingCryptoHelper CryptoHelper { get; }
+
+        internal ClientRemotePowerShell RemotePowerShell { get; }
+    }
+
+    /// <summary>
+    /// Creates custom client remoting session transports for connection information instances.
+    /// </summary>
+    public interface IClientRemotingTransportProvider
+    {
+        /// <summary>
+        /// Determines whether this provider can create a transport for <paramref name="connectionInfo"/>.
+        /// </summary>
+        bool CanCreateTransport(RunspaceConnectionInfo connectionInfo);
+
+        /// <summary>
+        /// Creates a client remoting session transport.
+        /// </summary>
+        BaseClientSessionTransportManager CreateSessionTransport(
+            ClientRemotingTransportCreationContext context);
+    }
+
+    /// <summary>
+    /// Options used when registering a client remoting transport provider.
+    /// </summary>
+    public sealed class ClientRemotingTransportProviderOptions
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether this provider can replace built-in transport handling.
+        /// </summary>
+        public bool ReplaceBuiltInTransports { get; set; }
+
+        /// <summary>
+        /// Gets or sets the provider priority. Higher priority providers are tried first.
+        /// </summary>
+        public int Priority { get; set; }
+    }
+
+    /// <summary>
+    /// Process-scoped registry for client remoting transport providers.
+    /// </summary>
+    public static class ClientRemotingTransportProviderRegistry
+    {
+        private static readonly object s_syncObject = new object();
+        private static readonly List<Registration> s_registrations = new List<Registration>();
+        private static long s_nextRegistrationOrder;
+
+        /// <summary>
+        /// Registers a client remoting transport provider.
+        /// </summary>
+        public static IDisposable Register(
+            IClientRemotingTransportProvider provider,
+            ClientRemotingTransportProviderOptions options = null)
+        {
+            ArgumentNullException.ThrowIfNull(provider);
+
+            options ??= new ClientRemotingTransportProviderOptions();
+
+            lock (s_syncObject)
+            {
+                Registration registration = new Registration(
+                    provider,
+                    options.ReplaceBuiltInTransports,
+                    options.Priority,
+                    s_nextRegistrationOrder++);
+
+                s_registrations.Add(registration);
+                SortRegistrations();
+                return registration;
+            }
+        }
+
+        internal static bool CanCreateRunspacePoolTransport(RunspaceConnectionInfo connectionInfo)
+        {
+            ArgumentNullException.ThrowIfNull(connectionInfo);
+
+            return IsBuiltInRunspacePoolConnectionInfo(connectionInfo)
+                || connectionInfo.CanCreateClientRemotingTransport
+                || TryGetProvider(connectionInfo, out _);
+        }
+
+        internal static bool WillUseRegisteredProvider(RunspaceConnectionInfo connectionInfo)
+        {
+            ArgumentNullException.ThrowIfNull(connectionInfo);
+
+            return TryGetProvider(connectionInfo, out _);
+        }
+
+        internal static BaseClientSessionTransportManager CreateSessionTransport(
+            ClientRemotingTransportCreationContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            if (TryGetProvider(context.ConnectionInfo, out IClientRemotingTransportProvider provider))
+            {
+                BaseClientSessionTransportManager transport = provider.CreateSessionTransport(context);
+                return transport ?? throw PSTraceSource.NewInvalidOperationException(
+                    RemotingErrorIdStrings.GeneralError,
+                    0,
+                    nameof(IClientRemotingTransportProvider.CreateSessionTransport));
+            }
+
+            BaseClientSessionTransportManager customTransport = context.ConnectionInfo.CreateClientSessionTransportManager(context);
+            return customTransport ?? throw PSTraceSource.NewInvalidOperationException(
+                RemotingErrorIdStrings.GeneralError,
+                0,
+                nameof(RunspaceConnectionInfo.CreateClientSessionTransportManager));
+        }
+
+        private static bool TryGetProvider(
+            RunspaceConnectionInfo connectionInfo,
+            out IClientRemotingTransportProvider provider)
+        {
+            Registration[] registrations;
+            lock (s_syncObject)
+            {
+                registrations = s_registrations.ToArray();
+            }
+
+            bool isBuiltIn = IsBuiltInConnectionInfo(connectionInfo);
+            foreach (Registration registration in registrations)
+            {
+                if (isBuiltIn && !registration.ReplaceBuiltInTransports)
+                {
+                    continue;
+                }
+
+                if (registration.Provider.CanCreateTransport(connectionInfo))
+                {
+                    provider = registration.Provider;
+                    return true;
+                }
+            }
+
+            provider = null;
+            return false;
+        }
+
+        private static bool IsBuiltInConnectionInfo(RunspaceConnectionInfo connectionInfo)
+        {
+            return connectionInfo is WSManConnectionInfo
+                || connectionInfo is NewProcessConnectionInfo
+                || connectionInfo is NamedPipeConnectionInfo
+                || connectionInfo is SSHConnectionInfo
+                || connectionInfo is VMConnectionInfo
+                || connectionInfo is ContainerConnectionInfo;
+        }
+
+        private static bool IsBuiltInRunspacePoolConnectionInfo(RunspaceConnectionInfo connectionInfo)
+        {
+            return connectionInfo is WSManConnectionInfo
+                || connectionInfo is NewProcessConnectionInfo
+                || connectionInfo is NamedPipeConnectionInfo
+                || connectionInfo is VMConnectionInfo
+                || connectionInfo is ContainerConnectionInfo;
+        }
+
+        private static void SortRegistrations()
+        {
+            s_registrations.Sort(static (left, right) =>
+            {
+                int priorityComparison = right.Priority.CompareTo(left.Priority);
+                return priorityComparison != 0
+                    ? priorityComparison
+                    : left.RegistrationOrder.CompareTo(right.RegistrationOrder);
+            });
+        }
+
+        private sealed class Registration : IDisposable
+        {
+            internal Registration(
+                IClientRemotingTransportProvider provider,
+                bool replaceBuiltInTransports,
+                int priority,
+                long registrationOrder)
+            {
+                Provider = provider;
+                ReplaceBuiltInTransports = replaceBuiltInTransports;
+                Priority = priority;
+                RegistrationOrder = registrationOrder;
+            }
+
+            internal IClientRemotingTransportProvider Provider { get; }
+
+            internal bool ReplaceBuiltInTransports { get; }
+
+            internal int Priority { get; }
+
+            internal long RegistrationOrder { get; }
+
+            public void Dispose()
+            {
+                lock (s_syncObject)
+                {
+                    s_registrations.Remove(this);
+                }
+            }
+        }
+    }
+}

--- a/src/System.Management.Automation/engine/remoting/client/RemotingProtocol2.cs
+++ b/src/System.Management.Automation/engine/remoting/client/RemotingProtocol2.cs
@@ -921,13 +921,7 @@ namespace System.Management.Automation.Internal
         {
             get
             {
-                if (_transportManager != null &&
-                    _transportManager is WSManClientSessionTransportManager)
-                {
-                    return ((WSManClientSessionTransportManager)(_transportManager)).MaxRetryConnectionTime;
-                }
-
-                return 0;
+                return _transportManager?.MaxRetryConnectionTime ?? 0;
             }
         }
 
@@ -939,8 +933,7 @@ namespace System.Management.Automation.Internal
         {
             get
             {
-                WSManClientSessionTransportManager wsmanTransportManager = _transportManager as WSManClientSessionTransportManager;
-                return wsmanTransportManager != null && wsmanTransportManager.SupportsDisconnect;
+                return _transportManager?.SupportsDisconnect ?? false;
             }
         }
 

--- a/src/System.Management.Automation/engine/remoting/client/remotingprotocolimplementation.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remotingprotocolimplementation.cs
@@ -80,10 +80,12 @@ namespace System.Management.Automation.Remoting
 
             // Create transport manager
             _cryptoHelper = cryptoHelper;
-            _transportManager = _connectionInfo.CreateClientSessionTransportManager(
+            _transportManager = ClientRemotingTransportProviderRegistry.CreateSessionTransport(
+                new ClientRemotingTransportCreationContext(
                 _session.RemoteRunspacePoolInternal.InstanceId,
                 _session.RemoteRunspacePoolInternal.Name,
-                cryptoHelper);
+                    _connectionInfo,
+                    cryptoHelper));
 
             _transportManager.DataReceived += DispatchInputQueueData;
             _transportManager.WSManTransportErrorOccured += HandleTransportError;
@@ -300,12 +302,8 @@ namespace System.Management.Automation.Remoting
             // once session is established.. start receiving data (if not already done and only apples to wsmanclientsessionTM)
             if (arg.SessionStateInfo.State == RemoteSessionState.Established)
             {
-                WSManClientSessionTransportManager tm = _transportManager as WSManClientSessionTransportManager;
-                if (tm != null)
-                {
-                    tm.AdjustForProtocolVariations(_session.ServerProtocolVersion);
-                    tm.StartReceivingData();
-                }
+                _transportManager.AdjustForProtocolVariations(_session.ServerProtocolVersion);
+                _transportManager.StartReceivingData();
             }
 
             // Close the transport manager only after powershell's close their transports

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -4341,6 +4341,11 @@ namespace System.Management.Automation.Remoting
         }
 
         /// <summary>
+        /// Gets client-only options used by custom remoting transports.
+        /// </summary>
+        public IDictionary<string, object> ClientTransportOptions { get; } = new Dictionary<string, object>(StringComparer.Ordinal);
+
+        /// <summary>
         /// The MaximumConnectionRedirectionCount parameter enables the implicit redirection functionality.
         /// -1 = no limit
         ///  0 = no redirection.

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -157,6 +157,11 @@ namespace System.Management.Automation.Runspaces
         public abstract string CertificateThumbprint { get; set; }
 
         /// <summary>
+        /// Gets client-only options used by custom remoting transports.
+        /// </summary>
+        public IDictionary<string, object> ClientTransportOptions { get; } = new Dictionary<string, object>(StringComparer.Ordinal);
+
+        /// <summary>
         /// Culture that the remote session should use.
         /// </summary>
         public CultureInfo Culture
@@ -293,6 +298,7 @@ namespace System.Management.Automation.Runspaces
             _openTimeout = TimeSpanToTimeOutMs(options.OpenTimeout);
             CancelTimeout = TimeSpanToTimeOutMs(options.CancelTimeout);
             OperationTimeout = TimeSpanToTimeOutMs(options.OperationTimeout);
+            CopyClientTransportOptionsFrom(options.ClientTransportOptions);
 
             // Special case for idle timeout.  A value of milliseconds == -1
             // (BaseTransportManager.UseServerDefaultIdleTimeout) is allowed for
@@ -339,6 +345,11 @@ namespace System.Management.Automation.Runspaces
         #region Public methods
 
         /// <summary>
+        /// Gets a value indicating whether this connection info can create a custom client remoting transport.
+        /// </summary>
+        protected internal virtual bool CanCreateClientRemotingTransport => false;
+
+        /// <summary>
         /// Creates the appropriate client session transportmanager.
         /// </summary>
         /// <param name="instanceId">Runspace/Pool instance Id.</param>
@@ -353,12 +364,53 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
+        /// Creates the appropriate client session transportmanager.
+        /// </summary>
+        /// <param name="context">The transport creation context.</param>
+        public virtual BaseClientSessionTransportManager CreateClientSessionTransportManager(
+            ClientRemotingTransportCreationContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            return CreateClientSessionTransportManager(
+                context.RunspacePoolInstanceId,
+                context.SessionName,
+                context.CryptoHelper);
+        }
+
+        /// <summary>
         /// Create a copy of the connection info object.
         /// </summary>
         /// <returns>Copy of the connection info object.</returns>
         public virtual RunspaceConnectionInfo Clone()
         {
             throw new PSNotImplementedException();
+        }
+
+        /// <summary>
+        /// Copies client transport options to another connection info.
+        /// </summary>
+        /// <param name="target">The target connection info.</param>
+        protected void CopyClientTransportOptionsTo(RunspaceConnectionInfo target)
+        {
+            ArgumentNullException.ThrowIfNull(target);
+
+            target.CopyClientTransportOptionsFrom(ClientTransportOptions);
+        }
+
+        private void CopyClientTransportOptionsFrom(IDictionary<string, object> options)
+        {
+            ClientTransportOptions.Clear();
+
+            if (options == null)
+            {
+                return;
+            }
+
+            foreach (KeyValuePair<string, object> option in options)
+            {
+                ClientTransportOptions.Add(option.Key, option.Value);
+            }
         }
 
         #endregion
@@ -1109,6 +1161,7 @@ namespace System.Management.Automation.Runspaces
             result.DisconnectedOn = this.DisconnectedOn;
             result.ExpiresOn = this.ExpiresOn;
             result.MaxConnectionRetryCount = this.MaxConnectionRetryCount;
+            CopyClientTransportOptionsTo(result);
 
             return result;
         }
@@ -1651,6 +1704,7 @@ namespace System.Management.Automation.Runspaces
             result.RunAs32 = this.RunAs32;
             result.PSVersion = this.PSVersion;
             result.Process = Process;
+            CopyClientTransportOptionsTo(result);
             return result;
         }
 
@@ -1897,6 +1951,7 @@ namespace System.Management.Automation.Runspaces
             newCopy._appDomainName = _appDomainName;
             newCopy.OpenTimeout = this.OpenTimeout;
             newCopy.CustomPipeName = this.CustomPipeName;
+            CopyClientTransportOptionsTo(newCopy);
 
             return newCopy;
         }
@@ -2166,6 +2221,7 @@ namespace System.Management.Automation.Runspaces
             newCopy.Subsystem = Subsystem;
             newCopy.ConnectingTimeout = ConnectingTimeout;
             newCopy.Options = Options;
+            CopyClientTransportOptionsTo(newCopy);
 
             return newCopy;
         }
@@ -2985,6 +3041,7 @@ namespace System.Management.Automation.Runspaces
         public override RunspaceConnectionInfo Clone()
         {
             VMConnectionInfo result = new VMConnectionInfo(Credential, VMGuid, ComputerName, ConfigurationName);
+            CopyClientTransportOptionsTo(result);
             return result;
         }
 
@@ -3129,6 +3186,7 @@ namespace System.Management.Automation.Runspaces
         public override RunspaceConnectionInfo Clone()
         {
             ContainerConnectionInfo newCopy = new ContainerConnectionInfo(ContainerProc);
+            CopyClientTransportOptionsTo(newCopy);
             return newCopy;
         }
 

--- a/src/System.Management.Automation/engine/remoting/common/fragmentor.cs
+++ b/src/System.Management.Automation/engine/remoting/common/fragmentor.cs
@@ -645,6 +645,17 @@ namespace System.Management.Automation.Remoting
             }
         }
 
+        internal bool HasData
+        {
+            get
+            {
+                lock (_syncObject)
+                {
+                    return _length > 0;
+                }
+            }
+        }
+
         /// <summary>
         /// Read the currently accumulated data in queued memory streams.
         /// </summary>

--- a/src/System.Management.Automation/engine/remoting/fanin/BaseTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/BaseTransportManager.cs
@@ -144,13 +144,36 @@ namespace System.Management.Automation.Remoting
     /// <summary>
     /// Robust Connection notifications.
     /// </summary>
-    internal enum ConnectionStatus
+    public enum ConnectionStatus
     {
+        /// <summary>
+        /// Network failure was detected.
+        /// </summary>
         NetworkFailureDetected = 1,
+
+        /// <summary>
+        /// The transport is retrying after a network failure.
+        /// </summary>
         ConnectionRetryAttempt = 2,
+
+        /// <summary>
+        /// The transport reconnected after a network failure.
+        /// </summary>
         ConnectionRetrySucceeded = 3,
+
+        /// <summary>
+        /// The remote endpoint is starting automatic disconnect.
+        /// </summary>
         AutoDisconnectStarting = 4,
+
+        /// <summary>
+        /// The remote endpoint completed automatic disconnect.
+        /// </summary>
         AutoDisconnectSucceeded = 5,
+
+        /// <summary>
+        /// Retry was aborted because of an internal transport error.
+        /// </summary>
         InternalErrorAbort = 6
     }
 
@@ -372,6 +395,15 @@ namespace System.Management.Automation.Remoting
                 s_baseTracer.WriteLine("{0} is not a valid stream", stream);
             }
             // process data
+            ProcessRawData(data, dataPriority, dataAvailableCallback);
+        }
+
+        internal void ProcessRawData(byte[] data,
+            DataPriorityType dataPriority,
+            ReceiveDataCollection.OnDataAvailableCallback dataAvailableCallback)
+        {
+            Dbg.Assert(data != null, "Cannot process null data");
+
             ReceivedDataCollection.ProcessRawData(data, dataPriority, dataAvailableCallback);
         }
 
@@ -426,7 +458,7 @@ namespace System.Management.Automation.Remoting
         /// Crypto handler to be used for encrypting/decrypting
         /// secure strings.
         /// </summary>
-        internal PSRemotingCryptoHelper CryptoHelper { get; set; }
+        protected internal PSRemotingCryptoHelper CryptoHelper { get; set; }
 
         /// <summary>
         /// A data buffer used to store data received from remote machine.
@@ -497,12 +529,19 @@ namespace System.Management.Automation.Remoting.Client
 
         #region Constructors
 
-        internal BaseClientTransportManager(Guid runspaceId, PSRemotingCryptoHelper cryptoHelper)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseClientTransportManager"/> class.
+        /// </summary>
+        /// <param name="runspaceId">The runspace pool instance identifier.</param>
+        /// <param name="cryptoHelper">The remoting crypto helper.</param>
+        protected BaseClientTransportManager(Guid runspaceId, PSRemotingCryptoHelper cryptoHelper)
             : base(cryptoHelper)
         {
             RunspacePoolInstanceId = runspaceId;
             dataToBeSent = new PrioritySendDataCollection();
+            dataToBeSent.Fragmentor = Fragmentor;
             _onDataAvailableCallback = new ReceiveDataCollection.OnDataAvailableCallback(OnDataAvailableHandler);
+            _onDataToSendAvailableCallback = new PrioritySendDataCollection.OnDataAvailableCallback(OnDataToSendAvailableHandler);
             _callbackNotificationQueue = new Queue<CallbackNotificationInformation>();
         }
 
@@ -581,6 +620,8 @@ namespace System.Management.Automation.Remoting.Client
 
         #endregion
 
+        private readonly PrioritySendDataCollection.OnDataAvailableCallback _onDataToSendAvailableCallback;
+
         #region Properties
 
         /// <summary>
@@ -595,7 +636,25 @@ namespace System.Management.Automation.Remoting.Client
         /// <summary>
         /// Used to log crimson messages.
         /// </summary>
-        internal Guid RunspacePoolInstanceId { get; }
+        protected internal Guid RunspacePoolInstanceId { get; }
+
+        /// <summary>
+        /// Gets or sets the fragment size used by this transport manager.
+        /// </summary>
+        protected int FragmentSize
+        {
+            get
+            {
+                return Fragmentor.FragmentSize;
+            }
+
+            set
+            {
+                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+
+                dataToBeSent.SetFragmentSize(value);
+            }
+        }
 
         /// <summary>
         /// Raise the Connect completed handler.
@@ -605,9 +664,27 @@ namespace System.Management.Automation.Remoting.Client
             CreateCompleted.SafeInvoke(this, eventArgs);
         }
 
+        /// <summary>
+        /// Reports that the transport open operation completed successfully.
+        /// </summary>
+        protected void CompleteOpen(RunspaceConnectionInfo connectionInfo)
+        {
+            ArgumentNullException.ThrowIfNull(connectionInfo);
+
+            RaiseCreateCompleted(new CreateCompleteEventArgs(connectionInfo));
+        }
+
         internal void RaiseConnectCompleted()
         {
             ConnectCompleted.SafeInvoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Reports that the transport connect operation completed successfully.
+        /// </summary>
+        protected void CompleteConnect()
+        {
+            RaiseConnectCompleted();
         }
 
         internal void RaiseDisconnectCompleted()
@@ -615,9 +692,25 @@ namespace System.Management.Automation.Remoting.Client
             DisconnectCompleted.SafeInvoke(this, EventArgs.Empty);
         }
 
+        /// <summary>
+        /// Reports that the transport disconnect operation completed successfully.
+        /// </summary>
+        protected void CompleteDisconnect()
+        {
+            RaiseDisconnectCompleted();
+        }
+
         internal void RaiseReconnectCompleted()
         {
             ReconnectCompleted.SafeInvoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Reports that the transport reconnect operation completed successfully.
+        /// </summary>
+        protected void CompleteReconnect()
+        {
+            RaiseReconnectCompleted();
         }
 
         /// <summary>
@@ -629,11 +722,27 @@ namespace System.Management.Automation.Remoting.Client
         }
 
         /// <summary>
+        /// Reports that the transport close operation completed successfully.
+        /// </summary>
+        protected void CompleteClose()
+        {
+            RaiseCloseCompleted();
+        }
+
+        /// <summary>
         /// Raise the ReadyForDisconnect event.
         /// </summary>
         internal void RaiseReadyForDisconnect()
         {
             ReadyForDisconnect.SafeInvoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Reports that the transport is ready for a disconnect operation.
+        /// </summary>
+        protected void CompleteReadyForDisconnect()
+        {
+            RaiseReadyForDisconnect();
         }
 
         /// <summary>
@@ -670,9 +779,35 @@ namespace System.Management.Automation.Remoting.Client
                     break;
             }
 
+            if (args != null)
+            {
+                ReportRobustConnectionNotification(args.Notification);
+            }
+        }
+
+        /// <summary>
+        /// Reports a robust connection status notification.
+        /// </summary>
+        /// <param name="notification">The robust connection notification.</param>
+        protected void ReportRobustConnectionNotification(ConnectionStatus notification)
+        {
+            switch (notification)
+            {
+                case ConnectionStatus.NetworkFailureDetected:
+                case ConnectionStatus.ConnectionRetryAttempt:
+                case ConnectionStatus.ConnectionRetrySucceeded:
+                case ConnectionStatus.AutoDisconnectStarting:
+                case ConnectionStatus.AutoDisconnectSucceeded:
+                case ConnectionStatus.InternalErrorAbort:
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(notification));
+            }
+
             // Queue worker item to raise the event so that all robust connection
             // events are raised in the same order as received.
-            EnqueueAndStartProcessingThread(null, null, args);
+            EnqueueAndStartProcessingThread(null, null, new ConnectionStatusEventArgs(notification));
         }
 
         /// <summary>
@@ -687,6 +822,89 @@ namespace System.Management.Automation.Remoting.Client
         internal void RaiseDelayStreamProcessedEvent()
         {
             DelayStreamRequestProcessed.SafeInvoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Reports that the delay-stream request was processed.
+        /// </summary>
+        protected void CompleteDelayStreamProcessed()
+        {
+            RaiseDelayStreamProcessedEvent();
+        }
+
+        /// <summary>
+        /// Reads a pending outbound remoting data fragment, optionally registering for a future callback.
+        /// </summary>
+        protected byte[] ReadDataToSend(
+            bool registerCallbackIfNoDataAvailable,
+            out ClientRemotingDataPriority priority)
+        {
+            DataPriorityType dataPriority;
+            byte[] data = dataToBeSent.ReadOrRegisterCallback(
+                registerCallbackIfNoDataAvailable ? _onDataToSendAvailableCallback : null,
+                out dataPriority);
+
+            priority = dataPriority == DataPriorityType.PromptResponse
+                ? ClientRemotingDataPriority.PromptResponse
+                : ClientRemotingDataPriority.Default;
+
+            return data;
+        }
+
+        /// <summary>
+        /// Called when outbound data is available after <see cref="ReadDataToSend"/> registered for notification.
+        /// </summary>
+        protected virtual void OnDataToSendAvailable(
+            ReadOnlyMemory<byte> data,
+            ClientRemotingDataPriority priority)
+        {
+        }
+
+        private void OnDataToSendAvailableHandler(byte[] data, DataPriorityType priorityType)
+        {
+            ClientRemotingDataPriority priority = priorityType == DataPriorityType.PromptResponse
+                ? ClientRemotingDataPriority.PromptResponse
+                : ClientRemotingDataPriority.Default;
+
+            OnDataToSendAvailable(data, priority);
+        }
+
+        /// <summary>
+        /// Processes a received remoting data fragment.
+        /// </summary>
+        /// <param name="data">The received remoting data fragment.</param>
+        /// <param name="priority">The priority stream for the received data.</param>
+        protected void ProcessReceivedData(byte[] data, ClientRemotingDataPriority priority)
+        {
+            ArgumentNullException.ThrowIfNull(data);
+
+            ProcessRawData(data, ToDataPriorityType(priority));
+        }
+
+        /// <summary>
+        /// Reports a transport error through the remoting transport error pipeline.
+        /// </summary>
+        protected void ReportTransportError(Exception exception, TransportMethodEnum method)
+        {
+            ArgumentNullException.ThrowIfNull(exception);
+
+            PSRemotingTransportException transportException = exception as PSRemotingTransportException
+                ?? new PSRemotingTransportException(exception.Message, exception);
+
+            EnqueueAndStartProcessingThread(
+                null,
+                new TransportErrorOccuredEventArgs(transportException, method),
+                null);
+        }
+
+        private static DataPriorityType ToDataPriorityType(ClientRemotingDataPriority priority)
+        {
+            return priority switch
+            {
+                ClientRemotingDataPriority.Default => DataPriorityType.Default,
+                ClientRemotingDataPriority.PromptResponse => DataPriorityType.PromptResponse,
+                _ => throw new ArgumentOutOfRangeException(nameof(priority)),
+            };
         }
 
         #endregion
@@ -719,6 +937,38 @@ namespace System.Management.Automation.Remoting.Client
                 // Enqueue an Exception to process in a thread-pool thread. Processing
                 // Exception in a thread pool thread is important as calling
                 // WSManCloseShell/Command from a Receive callback results in a deadlock.
+                tracer.WriteLine("Exception processing data. {0}", exception.Message);
+
+                PSRemotingTransportException e = new PSRemotingTransportException(exception.Message);
+                TransportErrorOccuredEventArgs eventargs = new TransportErrorOccuredEventArgs(e,
+                                    TransportMethodEnum.ReceiveShellOutputEx);
+                EnqueueAndStartProcessingThread(null, eventargs, null);
+                return;
+            }
+        }
+
+        internal virtual void ProcessRawData(byte[] data, DataPriorityType priority)
+        {
+            if (isClosed)
+            {
+                return;
+            }
+
+            try
+            {
+                base.ProcessRawData(data, priority, _onDataAvailableCallback);
+            }
+            catch (PSRemotingTransportException pte)
+            {
+                tracer.WriteLine("Exception processing data. {0}", pte.Message);
+                TransportErrorOccuredEventArgs eventargs = new TransportErrorOccuredEventArgs(pte,
+                                    TransportMethodEnum.ReceiveShellOutputEx);
+                EnqueueAndStartProcessingThread(null, eventargs, null);
+
+                return;
+            }
+            catch (Exception exception)
+            {
                 tracer.WriteLine("Exception processing data. {0}", exception.Message);
 
                 PSRemotingTransportException e = new PSRemotingTransportException(exception.Message);
@@ -978,6 +1228,10 @@ namespace System.Management.Automation.Remoting.Client
         /// </param>
         internal virtual void ProcessPrivateData(object privateData)
         {
+            if (privateData is ConnectionStatusEventArgs connectionStatus)
+            {
+                RaiseRobustConnectionNotification(connectionStatus);
+            }
         }
 
         internal class CallbackNotificationInformation
@@ -1000,7 +1254,10 @@ namespace System.Management.Automation.Remoting.Client
         /// </summary>
         public abstract void CreateAsync();
 
-        internal abstract void ConnectAsync();
+        /// <summary>
+        /// Connects a disconnected transport manager.
+        /// </summary>
+        protected internal abstract void ConnectAsync();
 
         /// <summary>
         /// The caller should make sure the call is synchronized.
@@ -1011,15 +1268,17 @@ namespace System.Management.Automation.Remoting.Client
             dataToBeSent.Clear();
         }
 
-        internal virtual void StartReceivingData()
+        /// <summary>
+        /// Starts receiving transport data after the remoting protocol is established.
+        /// </summary>
+        protected internal virtual void StartReceivingData()
         {
-            throw new NotImplementedException();
         }
 
         /// <summary>
         /// Method to have transport prepare for a disconnect operation.
         /// </summary>
-        internal virtual void PrepareForDisconnect()
+        protected internal virtual void PrepareForDisconnect()
         {
             throw new NotImplementedException();
         }
@@ -1027,7 +1286,7 @@ namespace System.Management.Automation.Remoting.Client
         /// <summary>
         /// Method to resume post disconnect operations.
         /// </summary>
-        internal virtual void PrepareForConnect()
+        protected internal virtual void PrepareForConnect()
         {
             throw new NotImplementedException();
         }
@@ -1089,9 +1348,29 @@ namespace System.Management.Automation.Remoting.Client
     {
         #region Constructors
 
-        internal BaseClientSessionTransportManager(Guid runspaceId, PSRemotingCryptoHelper cryptoHelper)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseClientSessionTransportManager"/> class.
+        /// </summary>
+        /// <param name="runspaceId">The runspace pool instance identifier.</param>
+        /// <param name="cryptoHelper">The remoting crypto helper.</param>
+        protected BaseClientSessionTransportManager(Guid runspaceId, PSRemotingCryptoHelper cryptoHelper)
             : base(runspaceId, cryptoHelper)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseClientSessionTransportManager"/> class.
+        /// </summary>
+        protected BaseClientSessionTransportManager(ClientRemotingTransportCreationContext context)
+            : this(ValidateContext(context).RunspacePoolInstanceId, ValidateContext(context).CryptoHelper)
+        {
+            TransportConnectionInfo = context.ConnectionInfo;
+        }
+
+        private static ClientRemotingTransportCreationContext ValidateContext(ClientRemotingTransportCreationContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            return context;
         }
 
         #endregion
@@ -1112,8 +1391,25 @@ namespace System.Management.Automation.Remoting.Client
         /// true if the command has input.
         /// </param>
         /// <returns></returns>
-        internal virtual BaseClientCommandTransportManager CreateClientCommandTransportManager(RunspaceConnectionInfo connectionInfo,
-                    ClientRemotePowerShell cmd, bool noInput)
+        internal virtual BaseClientCommandTransportManager CreateClientCommandTransportManager(
+            RunspaceConnectionInfo connectionInfo,
+            ClientRemotePowerShell cmd,
+            bool noInput)
+        {
+            return CreateClientCommandTransportManager(
+                new ClientCommandTransportCreationContext(
+                    connectionInfo,
+                    cmd,
+                    noInput,
+                    this,
+                    CryptoHelper));
+        }
+
+        /// <summary>
+        /// Creates a command transport manager.
+        /// </summary>
+        protected virtual BaseClientCommandTransportManager CreateClientCommandTransportManager(
+            ClientCommandTransportCreationContext context)
         {
             throw new NotImplementedException();
         }
@@ -1130,7 +1426,7 @@ namespace System.Management.Automation.Remoting.Client
         /// <summary>
         /// Temporarily disconnect an active session.
         /// </summary>
-        internal virtual void DisconnectAsync()
+        protected internal virtual void DisconnectAsync()
         {
             throw new NotImplementedException();
         }
@@ -1138,7 +1434,7 @@ namespace System.Management.Automation.Remoting.Client
         /// <summary>
         /// Reconnect back a temporarily disconnected session.
         /// </summary>
-        internal virtual void ReconnectAsync()
+        protected internal virtual void ReconnectAsync()
         {
             throw new NotImplementedException();
         }
@@ -1152,7 +1448,7 @@ namespace System.Management.Automation.Remoting.Client
         /// <param name="connectionInfo">
         /// Connection info object used for retrieving credential, auth. mechanism etc.
         /// </param>
-        internal virtual void Redirect(Uri newUri, RunspaceConnectionInfo connectionInfo)
+        protected internal virtual void Redirect(Uri newUri, RunspaceConnectionInfo connectionInfo)
         {
             throw new NotImplementedException();
         }
@@ -1162,27 +1458,67 @@ namespace System.Management.Automation.Remoting.Client
         /// This must be called only after Create callback (or Error form create) is received.
         /// Callers must catch the close completed event and call Redirect to perform the redirection.
         /// </summary>
-        internal virtual void PrepareForRedirection()
+        protected internal virtual void PrepareForRedirection()
         {
             throw new NotImplementedException();
         }
 
         #endregion
+
+        /// <summary>
+        /// Gets a value indicating whether the transport supports disconnect/connect semantics.
+        /// </summary>
+        protected internal virtual bool SupportsDisconnect => false;
+
+        /// <summary>
+        /// Gets the robust connection maximum retry time in milliseconds.
+        /// </summary>
+        protected internal virtual int MaxRetryConnectionTime => 0;
+
+        /// <summary>
+        /// Adjusts transport behavior after protocol negotiation.
+        /// </summary>
+        /// <param name="serverProtocolVersion">The negotiated server protocol version.</param>
+        protected internal virtual void AdjustForProtocolVariations(Version serverProtocolVersion)
+        {
+        }
+
+        /// <summary>
+        /// Gets the connection information used to create this transport, if it was created with a context.
+        /// </summary>
+        protected RunspaceConnectionInfo TransportConnectionInfo { get; }
     }
 
-    internal abstract class BaseClientCommandTransportManager : BaseClientTransportManager, IDisposable
+    /// <summary>
+    /// Remoting base client command transport manager.
+    /// </summary>
+    public abstract class BaseClientCommandTransportManager : BaseClientTransportManager, IDisposable
     {
         #region Private / Protected Data
 
         // pipeline in the form cmd1 | cmd2.. this is used by authz module for early validation.
-        protected StringBuilder cmdText;
-        protected SerializedDataStream serializedPipeline;
-        protected Guid powershellInstanceId;
+        internal StringBuilder cmdText;
+        internal SerializedDataStream serializedPipeline;
+        internal Guid powershellInstanceId;
+        private readonly SerializedDataStream.OnDataAvailableCallback _onInitialCommandDataAvailableCallback;
 
-        protected Guid PowershellInstanceId
+        internal Guid PowershellInstanceId
         {
             get { return powershellInstanceId; }
         }
+
+        /// <summary>
+        /// Gets the PowerShell instance identifier.
+        /// </summary>
+        protected Guid PowerShellInstanceId
+        {
+            get { return powershellInstanceId; }
+        }
+
+        /// <summary>
+        /// Gets the command text used by the transport protocol for audit and authorization.
+        /// </summary>
+        protected string CommandText { get; private set; }
 
         #endregion
 
@@ -1190,15 +1526,17 @@ namespace System.Management.Automation.Remoting.Client
 
         #region Constructors
 
-        protected BaseClientCommandTransportManager(ClientRemotePowerShell shell,
+        internal BaseClientCommandTransportManager(ClientRemotePowerShell shell,
             PSRemotingCryptoHelper cryptoHelper,
             BaseClientSessionTransportManager sessnTM) : base(sessnTM.RunspacePoolInstanceId, cryptoHelper)
         {
+            _onInitialCommandDataAvailableCallback = new SerializedDataStream.OnDataAvailableCallback(OnInitialCommandDataAvailable);
             Fragmentor.FragmentSize = sessnTM.Fragmentor.FragmentSize;
             Fragmentor.TypeTable = sessnTM.Fragmentor.TypeTable;
             dataToBeSent.Fragmentor = base.Fragmentor;
             // used for Crimson logging.
             powershellInstanceId = shell.PowerShell.InstanceId;
+            CommandText = shell.PowerShell.Commands.Commands.GetCommandStringForHistory();
 
             cmdText = new StringBuilder();
             foreach (System.Management.Automation.Runspaces.Command cmd in shell.PowerShell.Commands.Commands)
@@ -1223,6 +1561,20 @@ namespace System.Management.Automation.Remoting.Client
             Fragmentor.Fragment<object>(message, serializedPipeline);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseClientCommandTransportManager"/> class.
+        /// </summary>
+        protected BaseClientCommandTransportManager(ClientCommandTransportCreationContext context)
+            : this(ValidateContext(context).RemotePowerShell, ValidateContext(context).CryptoHelper, ValidateContext(context).SessionTransportManager)
+        {
+        }
+
+        private static ClientCommandTransportCreationContext ValidateContext(ClientCommandTransportCreationContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            return context;
+        }
+
         #endregion
 
         #region Events
@@ -1234,10 +1586,22 @@ namespace System.Management.Automation.Remoting.Client
             SignalCompleted.SafeInvoke(this, EventArgs.Empty);
         }
 
+        /// <summary>
+        /// Reports that the command signal operation completed successfully.
+        /// </summary>
+        protected void CompleteSignal()
+        {
+            RaiseSignalCompleted();
+        }
+
         #endregion
 
         #region Overrides
 
+        /// <summary>
+        /// Releases resources used by the transport manager.
+        /// </summary>
+        /// <param name="isDisposing">True when called from <see cref="IDisposable.Dispose"/>.</param>
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
@@ -1259,7 +1623,7 @@ namespace System.Management.Automation.Remoting.Client
         /// when disconnect is called on sessionTM . The TM's also dont maintain specific connection state
         /// This is done by DSHandlers.
         /// </summary>
-        internal virtual void ReconnectAsync()
+        protected internal virtual void ReconnectAsync()
         {
             throw new NotImplementedException();
         }
@@ -1267,9 +1631,23 @@ namespace System.Management.Automation.Remoting.Client
         /// <summary>
         /// Used by powershell/pipeline to send a stop message to the server command.
         /// </summary>
-        internal virtual void SendStopSignal()
+        protected internal virtual void SendStopSignal()
         {
             throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Reads the initial command data generated by the SDK.
+        /// </summary>
+        protected byte[] ReadInitialCommandData(bool registerCallbackIfNoDataAvailable)
+        {
+            return serializedPipeline.ReadOrRegisterCallback(
+                registerCallbackIfNoDataAvailable ? _onInitialCommandDataAvailableCallback : null);
+        }
+
+        private void OnInitialCommandDataAvailable(byte[] data, bool isEndFragment)
+        {
+            OnDataToSendAvailable(data, ClientRemotingDataPriority.Default);
         }
 
         #endregion

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -562,7 +562,10 @@ namespace System.Management.Automation.Remoting.Client
 
         #region Overrides
 
-        internal override void ConnectAsync()
+        /// <summary>
+        /// Connects a disconnected transport manager.
+        /// </summary>
+        protected internal override void ConnectAsync()
         {
             throw new NotImplementedException(RemotingErrorIdStrings.IPCTransportConnectError);
         }
@@ -1969,7 +1972,7 @@ namespace System.Management.Automation.Remoting.Client
 
             _connectionInfo = connectionInfo;
             _threadName = threadName;
-            Fragmentor.FragmentSize = RemoteSessionNamedPipeServer.NamedPipeBufferSizeForRemoting;
+            FragmentSize = RemoteSessionNamedPipeServer.NamedPipeBufferSizeForRemoting;
         }
 
         #endregion
@@ -2216,7 +2219,7 @@ namespace System.Management.Automation.Remoting.Client
 
         #region Overrides
 
-        internal override void ConnectAsync()
+        protected internal override void ConnectAsync()
         {
             throw new NotImplementedException(RemotingErrorIdStrings.IPCTransportConnectError);
         }
@@ -2268,7 +2271,7 @@ namespace System.Management.Automation.Remoting.Client
             }
         }
 
-        internal override void SendStopSignal()
+        protected internal override void SendStopSignal()
         {
             PSEtwLog.LogAnalyticInformational(PSEventId.WSManSignal,
                 PSOpcode.Disconnect, PSTask.None,

--- a/src/System.Management.Automation/engine/remoting/fanin/PriorityCollection.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/PriorityCollection.cs
@@ -50,6 +50,7 @@ namespace System.Management.Automation.Remoting
 
         // fragmentor used to serialize & fragment objects added to this collection.
         private Fragmentor _fragmentor;
+        private int _streamFragmentSize;
 
         // callbacks used if no data is available at any time.
         // these callbacks are used to notify when data becomes available under
@@ -58,6 +59,7 @@ namespace System.Management.Automation.Remoting
         private readonly SerializedDataStream.OnDataAvailableCallback _onSendCollectionDataAvailable;
         private bool _isHandlingCallback;
         private readonly object _readSyncObject = new object();
+        private readonly object _writeSyncObject = new object();
 
         /// <summary>
         /// Callback that is called once a fragmented data is available to send.
@@ -96,17 +98,139 @@ namespace System.Management.Automation.Remoting
             set
             {
                 Dbg.Assert(value != null, "Fragmentor cannot be null.");
-                _fragmentor = value;
-                // create serialized streams using fragment size.
-                string[] names = Enum.GetNames<DataPriorityType>();
-                _dataToBeSent = new SerializedDataStream[names.Length];
-                _dataSyncObjects = new object[names.Length];
-                for (int i = 0; i < names.Length; i++)
+
+                OnDataAvailableCallback callbackToRestore = null;
+                lock (_writeSyncObject)
                 {
-                    _dataToBeSent[i] = new SerializedDataStream(_fragmentor.FragmentSize);
-                    _dataSyncObjects[i] = new object();
+                    lock (_readSyncObject)
+                    {
+                        if (_fragmentor != null && HasPendingDataNoLock())
+                        {
+                            throw new InvalidOperationException("Fragmentor cannot be reset while outbound remoting data is pending.");
+                        }
+
+                        if (ReferenceEquals(_fragmentor, value) &&
+                            _dataToBeSent != null &&
+                            _streamFragmentSize == value.FragmentSize)
+                        {
+                            return;
+                        }
+
+                        callbackToRestore = _onDataAvailableCallback;
+                        _onDataAvailableCallback = null;
+                        ResetFragmentorNoLock(value);
+                    }
+                }
+
+                RestoreCallback(callbackToRestore);
+            }
+        }
+
+        internal bool CanResetFragmentor
+        {
+            get
+            {
+                lock (_writeSyncObject)
+                {
+                    lock (_readSyncObject)
+                    {
+                        return !HasPendingDataNoLock();
+                    }
                 }
             }
+        }
+
+        internal void SetFragmentSize(int fragmentSize)
+        {
+            OnDataAvailableCallback callbackToRestore = null;
+            lock (_writeSyncObject)
+            {
+                lock (_readSyncObject)
+                {
+                    Dbg.Assert(_fragmentor != null, "Fragmentor cannot be null while setting fragment size.");
+
+                    if (_fragmentor.FragmentSize == fragmentSize &&
+                        _dataToBeSent != null &&
+                        _streamFragmentSize == fragmentSize)
+                    {
+                        return;
+                    }
+
+                    if (HasPendingDataNoLock())
+                    {
+                        throw new InvalidOperationException("Fragmentor cannot be reset while outbound remoting data is pending.");
+                    }
+
+                    callbackToRestore = _onDataAvailableCallback;
+                    _onDataAvailableCallback = null;
+                    _fragmentor.FragmentSize = fragmentSize;
+                    ResetFragmentorNoLock(_fragmentor);
+                }
+            }
+
+            RestoreCallback(callbackToRestore);
+        }
+
+        internal bool HasPendingData
+        {
+            get
+            {
+                lock (_writeSyncObject)
+                {
+                    lock (_readSyncObject)
+                    {
+                        if (_dataToBeSent == null)
+                        {
+                            return false;
+                        }
+
+                        return HasPendingDataNoLock();
+                    }
+                }
+            }
+        }
+
+        private void ResetFragmentorNoLock(Fragmentor fragmentor)
+        {
+            _fragmentor = fragmentor;
+            _streamFragmentSize = _fragmentor.FragmentSize;
+
+            // Create serialized streams using the current fragment size.
+            string[] names = Enum.GetNames<DataPriorityType>();
+            _dataToBeSent = new SerializedDataStream[names.Length];
+            _dataSyncObjects = new object[names.Length];
+            for (int i = 0; i < names.Length; i++)
+            {
+                _dataToBeSent[i] = new SerializedDataStream(_fragmentor.FragmentSize);
+                _dataSyncObjects[i] = new object();
+            }
+        }
+
+        private void RestoreCallback(OnDataAvailableCallback callbackToRestore)
+        {
+            if (callbackToRestore == null)
+            {
+                return;
+            }
+
+            byte[] data = ReadOrRegisterCallback(callbackToRestore, out DataPriorityType priorityType);
+            if (data != null)
+            {
+                callbackToRestore(data, priorityType);
+            }
+        }
+
+        private bool HasPendingDataNoLock()
+        {
+            foreach (SerializedDataStream stream in _dataToBeSent)
+            {
+                if (stream?.HasData == true)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -125,15 +249,19 @@ namespace System.Management.Automation.Remoting
         internal void Add<T>(RemoteDataObject<T> data, DataPriorityType priority)
         {
             Dbg.Assert(data != null, "Cannot send null data object");
-            Dbg.Assert(_fragmentor != null, "Fragmentor cannot be null while adding objects");
-            Dbg.Assert(_dataToBeSent != null, "Serialized streams are not initialized");
 
-            // make sure the only one object is fragmented and added to the collection
-            // at any give time. This way the order of fragment is maintained
-            // in the SendDataCollection(s).
-            lock (_dataSyncObjects[(int)priority])
+            lock (_writeSyncObject)
             {
-                _fragmentor.Fragment<T>(data, _dataToBeSent[(int)priority]);
+                Dbg.Assert(_fragmentor != null, "Fragmentor cannot be null while adding objects");
+                Dbg.Assert(_dataToBeSent != null, "Serialized streams are not initialized");
+
+                // make sure the only one object is fragmented and added to the collection
+                // at any give time. This way the order of fragment is maintained
+                // in the SendDataCollection(s).
+                lock (_dataSyncObjects[(int)priority])
+                {
+                    _fragmentor.Fragment<T>(data, _dataToBeSent[(int)priority]);
+                }
             }
         }
 
@@ -159,31 +287,37 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         internal void Clear()
         {
-            /*
-                NOTE: Error paths during initialization can cause _dataSyncObjects to be null
-                causing an unhandled exception in finalize and a process crash.
-                Verify arrays and dataToBeSent objects before referencing.
-            */
-            if (_dataSyncObjects != null && _dataToBeSent != null)
+            lock (_writeSyncObject)
             {
-                const int promptResponseIndex = (int)DataPriorityType.PromptResponse;
-                const int defaultIndex = (int)DataPriorityType.Default;
-
-                lock (_dataSyncObjects[promptResponseIndex])
+                lock (_readSyncObject)
                 {
-                    if (_dataToBeSent[promptResponseIndex] != null)
+                    /*
+                        NOTE: Error paths during initialization can cause _dataSyncObjects to be null
+                        causing an unhandled exception in finalize and a process crash.
+                        Verify arrays and dataToBeSent objects before referencing.
+                    */
+                    if (_dataSyncObjects != null && _dataToBeSent != null)
                     {
-                        _dataToBeSent[promptResponseIndex].Dispose();
-                        _dataToBeSent[promptResponseIndex] = null;
-                    }
-                }
+                        const int promptResponseIndex = (int)DataPriorityType.PromptResponse;
+                        const int defaultIndex = (int)DataPriorityType.Default;
 
-                lock (_dataSyncObjects[defaultIndex])
-                {
-                    if (_dataToBeSent[defaultIndex] != null)
-                    {
-                        _dataToBeSent[defaultIndex].Dispose();
-                        _dataToBeSent[defaultIndex] = null;
+                        lock (_dataSyncObjects[promptResponseIndex])
+                        {
+                            if (_dataToBeSent[promptResponseIndex] != null)
+                            {
+                                _dataToBeSent[promptResponseIndex].Dispose();
+                                _dataToBeSent[promptResponseIndex] = null;
+                            }
+                        }
+
+                        lock (_dataSyncObjects[defaultIndex])
+                        {
+                            if (_dataToBeSent[defaultIndex] != null)
+                            {
+                                _dataToBeSent[defaultIndex].Dispose();
+                                _dataToBeSent[defaultIndex] = null;
+                            }
+                        }
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
@@ -822,9 +822,14 @@ namespace System.Management.Automation.Remoting.Client
 
         internal WSManAPIDataCommon WSManAPIData { get; private set; }
 
-        internal bool SupportsDisconnect { get; private set; }
+        private bool _supportsDisconnect;
 
-        internal override void DisconnectAsync()
+        /// <summary>
+        /// Gets a value indicating whether the transport supports disconnect/connect semantics.
+        /// </summary>
+        protected internal override bool SupportsDisconnect => _supportsDisconnect;
+
+        protected internal override void DisconnectAsync()
         {
             Dbg.Assert(!isClosed, "object already disposed");
 
@@ -870,7 +875,7 @@ namespace System.Management.Automation.Remoting.Client
             }
         }
 
-        internal override void ReconnectAsync()
+        protected internal override void ReconnectAsync()
         {
             Dbg.Assert(!isClosed, "object already disposed");
             ReceivedDataCollection.PrepareForStreamConnect();
@@ -908,7 +913,7 @@ namespace System.Management.Automation.Remoting.Client
         /// <exception cref="PSRemotingTransportException">
         /// WSManConnectShellEx failed.
         /// </exception>
-        internal override void ConnectAsync()
+        protected internal override void ConnectAsync()
         {
             Dbg.Assert(!isClosed, "object already disposed");
             Dbg.Assert(!string.IsNullOrEmpty(ConnectionInfo.ShellUri), "shell uri cannot be null or empty.");
@@ -951,7 +956,7 @@ namespace System.Management.Automation.Remoting.Client
             AddSessionTransportManager(_sessionContextID, this);
 
             // session is implicitly assumed to support disconnect
-            SupportsDisconnect = true;
+            _supportsDisconnect = true;
 
             // Create Callback
             _connectSessionCallback = new WSManNativeApi.WSManShellAsync(new IntPtr(_sessionContextID), s_sessionConnectCallback);
@@ -995,7 +1000,7 @@ namespace System.Management.Automation.Remoting.Client
             }
         }
 
-        internal override void StartReceivingData()
+        protected internal override void StartReceivingData()
         {
             lock (syncObject)
             {
@@ -1256,7 +1261,7 @@ namespace System.Management.Automation.Remoting.Client
         ///   So if server version is known to be V2, we'll downgrade the max env size to 150KB (V2's default) if the current value is 500KB (V3 default)
         /// </summary>
         /// <param name="serverProtocolVersion">Server negotiated protocol version.</param>
-        internal void AdjustForProtocolVariations(Version serverProtocolVersion)
+        protected internal override void AdjustForProtocolVariations(Version serverProtocolVersion)
         {
             if (serverProtocolVersion <= RemotingConstants.ProtocolVersion_2_1)
             {
@@ -1286,6 +1291,9 @@ namespace System.Management.Automation.Remoting.Client
                         WSManNativeApi.WSManSessionOption.WSMAN_OPTION_SHELL_MAX_DATA_SIZE_PER_MESSAGE_KB,
                         out packetSize);
                     // packet size returned is in KB. Convert this into bytes
+                    // Startup data can still be queued when protocol negotiation completes.
+                    // Preserve existing WSMan behavior by using the downgraded size for future
+                    // command transports without rebuilding the active session send queue.
                     Fragmentor.FragmentSize = packetSize << 10;
                 }
             }
@@ -1297,7 +1305,7 @@ namespace System.Management.Automation.Remoting.Client
         /// This will close the internal WSMan Session handle. Callers must catch the close
         /// completed event and call Redirect to perform the redirection.
         /// </summary>
-        internal override void PrepareForRedirection()
+        protected internal override void PrepareForRedirection()
         {
             Dbg.Assert(!isClosed, "Transport manager must not be closed while preparing for redirection.");
 
@@ -1317,7 +1325,7 @@ namespace System.Management.Automation.Remoting.Client
         /// <exception cref="PSInvalidOperationException">
         /// 1. Create Session failed with a non-zero error code.
         /// </exception>
-        internal override void Redirect(Uri newUri, RunspaceConnectionInfo connectionInfo)
+        protected internal override void Redirect(Uri newUri, RunspaceConnectionInfo connectionInfo)
         {
             CloseSessionAndClearResources();
             tracer.WriteLine("Redirecting to URI: {0}", newUri);
@@ -1517,14 +1525,13 @@ namespace System.Management.Automation.Remoting.Client
                 WSManNativeApi.WSManSessionOption.WSMAN_OPTION_SHELL_MAX_DATA_SIZE_PER_MESSAGE_KB,
                 out packetSize);
             // packet size returned is in KB. Convert this into bytes..
-            Fragmentor.FragmentSize = packetSize << 10;
+            FragmentSize = packetSize << 10;
 
             // Get robust connections maximum retries time.
             WSManNativeApi.WSManGetSessionOptionAsDword(_wsManSessionHandle,
                 WSManNativeApi.WSManSessionOption.WSMAN_OPTION_MAX_RETRY_TIME,
                 out _maxRetryTime);
 
-            this.dataToBeSent.Fragmentor = base.Fragmentor;
             _noCompression = !connectionInfo.UseCompression;
             _noMachineProfile = connectionInfo.NoMachineProfile;
 
@@ -1756,7 +1763,10 @@ namespace System.Management.Automation.Remoting.Client
         /// <summary>
         /// Robust connection maximum retry time in milliseconds.
         /// </summary>
-        internal int MaxRetryConnectionTime
+        /// <summary>
+        /// Gets the robust connection maximum retry time in milliseconds.
+        /// </summary>
+        protected internal override int MaxRetryConnectionTime
         {
             get { return _maxRetryTime; }
         }
@@ -1925,7 +1935,7 @@ namespace System.Management.Automation.Remoting.Client
             }
 
             // check if the session supports disconnect
-            sessionTM.SupportsDisconnect = (flags & (int)WSManNativeApi.WSManCallbackFlags.WSMAN_FLAG_CALLBACK_SHELL_SUPPORTS_DISCONNECT) != 0;
+            sessionTM._supportsDisconnect = (flags & (int)WSManNativeApi.WSManCallbackFlags.WSMAN_FLAG_CALLBACK_SHELL_SUPPORTS_DISCONNECT) != 0;
 
             // openContent is used by redirection ie., while redirecting to
             // a new machine.. this is not needed anymore as the connection
@@ -2934,7 +2944,7 @@ namespace System.Management.Automation.Remoting.Client
             // Apply quota limits.. allow for data to be unlimited..
             ReceivedDataCollection.MaximumReceivedDataSize = connectionInfo.MaximumReceivedDataSizePerCommand;
             ReceivedDataCollection.MaximumReceivedObjectSize = connectionInfo.MaximumReceivedObjectSize;
-            _cmdLine = shell.PowerShell.Commands.Commands.GetCommandStringForHistory();
+            _cmdLine = CommandText;
             _onDataAvailableToSendCallback =
                 new PrioritySendDataCollection.OnDataAvailableCallback(OnDataAvailableCallback);
             _sessnTm = sessnTM;
@@ -2970,7 +2980,7 @@ namespace System.Management.Automation.Remoting.Client
         /// <exception cref="PSRemotingTransportException">
         /// WSManConnectShellCommandEx failed.
         /// </exception>
-        internal override void ConnectAsync()
+        protected internal override void ConnectAsync()
         {
             Dbg.Assert(!isClosed, "object already disposed");
             ReceivedDataCollection.PrepareForStreamConnect();
@@ -3095,7 +3105,7 @@ namespace System.Management.Automation.Remoting.Client
         /// <summary>
         /// Restores connection on a disconnected command.
         /// </summary>
-        internal override void ReconnectAsync()
+        protected internal override void ReconnectAsync()
         {
             ReceivedDataCollection.PrepareForStreamConnect();
             lock (syncObject)
@@ -3111,7 +3121,7 @@ namespace System.Management.Automation.Remoting.Client
         /// <summary>
         /// Used by powershell/pipeline to send a stop message to the server command.
         /// </summary>
-        internal override void SendStopSignal()
+        protected internal override void SendStopSignal()
         {
             lock (syncObject)
             {
@@ -3324,7 +3334,7 @@ namespace System.Management.Automation.Remoting.Client
         /// <summary>
         /// Method to have transport prepare for a disconnect operation.
         /// </summary>
-        internal override void PrepareForDisconnect()
+        protected internal override void PrepareForDisconnect()
         {
             _isDisconnectPending = true;
 
@@ -3343,7 +3353,7 @@ namespace System.Management.Automation.Remoting.Client
         /// <summary>
         /// Method to resume post disconnect operations.
         /// </summary>
-        internal override void PrepareForConnect()
+        protected internal override void PrepareForConnect()
         {
             _isDisconnectPending = false;
         }
@@ -4052,7 +4062,7 @@ namespace System.Management.Automation.Remoting.Client
             }
         }
 
-        internal override void StartReceivingData()
+        protected internal override void StartReceivingData()
         {
             PSEtwLog.LogAnalyticInformational(
                 PSEventId.WSManReceiveShellOutputEx,

--- a/test/xUnit/csharp/test_ClientRemotingTransportProvider.cs
+++ b/test/xUnit/csharp/test_ClientRemotingTransportProvider.cs
@@ -1,0 +1,782 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Management.Automation;
+using System.Management.Automation.Internal;
+using System.Management.Automation.Remoting;
+using System.Management.Automation.Remoting.Client;
+using System.Management.Automation.Runspaces;
+using System.Management.Automation.Runspaces.Internal;
+using Xunit;
+
+namespace PSTests.Parallel
+{
+    public static class ClientRemotingTransportProviderTests
+    {
+        [Fact]
+        public static void ClientTransportOptionsAreCopiedFromSessionOptionsAndClone()
+        {
+            const string optionName = "Test:Option";
+            object optionValue = new object();
+            var options = new PSSessionOption();
+            options.ClientTransportOptions.Add(optionName, optionValue);
+
+            var connectionInfo = new WSManConnectionInfo();
+            connectionInfo.SetSessionOptions(options);
+
+            Assert.Same(optionValue, connectionInfo.ClientTransportOptions[optionName]);
+
+            var copy = (WSManConnectionInfo)connectionInfo.Clone();
+
+            Assert.Same(optionValue, copy.ClientTransportOptions[optionName]);
+        }
+
+        [Fact]
+        public static void ProviderMustOptInToReplacingBuiltInConnectionInfo()
+        {
+            var provider = new TestProvider(_ => true);
+            var connectionInfo = new WSManConnectionInfo();
+
+            using (ClientRemotingTransportProviderRegistry.Register(provider))
+            {
+                Assert.False(ClientRemotingTransportProviderRegistry.WillUseRegisteredProvider(connectionInfo));
+            }
+
+            using (ClientRemotingTransportProviderRegistry.Register(
+                provider,
+                new ClientRemotingTransportProviderOptions { ReplaceBuiltInTransports = true }))
+            {
+                Assert.True(ClientRemotingTransportProviderRegistry.WillUseRegisteredProvider(connectionInfo));
+            }
+        }
+
+        [Fact]
+        public static void RegisteredProviderCreatesTransportForBuiltInConnectionInfoWhenReplacementIsEnabled()
+        {
+            var provider = new TestProvider(static connectionInfo => connectionInfo is WSManConnectionInfo);
+
+            using (ClientRemotingTransportProviderRegistry.Register(
+                provider,
+                new ClientRemotingTransportProviderOptions { ReplaceBuiltInTransports = true }))
+            using (RunspacePool runspacePool = RunspaceFactory.CreateRunspacePool(
+                minRunspaces: 1,
+                maxRunspaces: 1,
+                connectionInfo: new WSManConnectionInfo(),
+                host: null,
+                typeTable: null,
+                applicationArguments: null))
+            {
+                Assert.NotNull(runspacePool);
+                Assert.Equal(1, provider.CreateSessionTransportCount);
+            }
+        }
+
+        [Fact]
+        public static void RunspacePoolFactoryAcceptsOptedInCustomConnectionInfo()
+        {
+            using RunspacePool runspacePool = RunspaceFactory.CreateRunspacePool(
+                minRunspaces: 1,
+                maxRunspaces: 1,
+                connectionInfo: new CustomConnectionInfo(),
+                host: null,
+                typeTable: null,
+                applicationArguments: null);
+
+            Assert.NotNull(runspacePool);
+        }
+
+        [Fact]
+        public static void RunspacePoolFactoryAcceptsProviderBackedConnectionInfo()
+        {
+            using (ClientRemotingTransportProviderRegistry.Register(new TestProvider(static connectionInfo => connectionInfo is PassiveConnectionInfo)))
+            using (RunspacePool runspacePool = RunspaceFactory.CreateRunspacePool(
+                minRunspaces: 1,
+                maxRunspaces: 1,
+                connectionInfo: new PassiveConnectionInfo(),
+                host: null,
+                typeTable: null,
+                applicationArguments: null))
+            {
+                Assert.NotNull(runspacePool);
+            }
+        }
+
+        [Fact]
+        public static void RunspacePoolFactoryRejectsUnsupportedConnectionInfo()
+        {
+            Assert.Throws<NotSupportedException>(() => RunspaceFactory.CreateRunspacePool(
+                minRunspaces: 1,
+                maxRunspaces: 1,
+                connectionInfo: new PassiveConnectionInfo(),
+                host: null,
+                typeTable: null,
+                applicationArguments: null));
+        }
+
+        [Fact]
+        public static void RunspacePoolFactoryStillRejectsSshConnectionInfoWithoutProvider()
+        {
+            Assert.Throws<NotSupportedException>(() => RunspaceFactory.CreateRunspacePool(
+                minRunspaces: 1,
+                maxRunspaces: 1,
+                connectionInfo: new SSHConnectionInfo("user", "host", keyFilePath: null),
+                host: null,
+                typeTable: null,
+                applicationArguments: null));
+        }
+
+        [Fact]
+        public static void SessionTransportContextConstructorInitializesProtectedSurface()
+        {
+            var connectionInfo = new CustomConnectionInfo();
+            var context = CreateContext(connectionInfo);
+            var transportManager = new TestSessionTransportManager(context);
+
+            Assert.Equal(context.RunspacePoolInstanceId, transportManager.GetRunspacePoolInstanceId());
+            Assert.Same(connectionInfo, transportManager.GetTransportConnectionInfo());
+
+            transportManager.SetFragmentSize(64 * 1024);
+
+            Assert.Equal(64 * 1024, transportManager.GetFragmentSize());
+        }
+
+        [Fact]
+        public static void ContextConstructorsValidateNullBeforeDelegating()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TestSessionTransportManager(null));
+            Assert.Throws<ArgumentNullException>(() => new TestCommandTransportManager(null));
+        }
+
+        [Fact]
+        public static void TransportProtectedSurfaceValidatesInputs()
+        {
+            var context = CreateContext(new CustomConnectionInfo());
+            var transportManager = new TestSessionTransportManager(context);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => transportManager.SetFragmentSize(0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => transportManager.SetFragmentSize(-1));
+            Assert.Throws<ArgumentNullException>(() => transportManager.ProcessIncomingData(null, ClientRemotingDataPriority.Default));
+            Assert.Throws<ArgumentOutOfRangeException>(() => transportManager.ProcessIncomingData(Array.Empty<byte>(), (ClientRemotingDataPriority)99));
+            Assert.Throws<ArgumentOutOfRangeException>(() => transportManager.ReportInvalidRobustConnectionNotification());
+        }
+
+        [Fact]
+        public static void RegistryRejectsNullCustomConnectionInfoTransport()
+        {
+            var context = CreateContext(new NullCustomConnectionInfo());
+
+            Assert.Throws<PSInvalidOperationException>(() => ClientRemotingTransportProviderRegistry.CreateSessionTransport(context));
+        }
+
+        [Fact]
+        public static void RegistryRejectsNullProviderTransport()
+        {
+            var context = CreateContext(new PassiveConnectionInfo());
+
+            using (ClientRemotingTransportProviderRegistry.Register(new NullTransportProvider()))
+            {
+                Assert.Throws<PSInvalidOperationException>(() => ClientRemotingTransportProviderRegistry.CreateSessionTransport(context));
+            }
+        }
+
+        [Fact]
+        public static void SessionTransportCanReadSdkQueuedData()
+        {
+            var context = CreateContext(new CustomConnectionInfo());
+            var transportManager = new TestSessionTransportManager(context);
+            var data = CreateTestRemoteDataObject(context.RunspacePoolInstanceId);
+
+            transportManager.QueueDataToSend(data, ClientRemotingDataPriority.Default);
+
+            byte[] bytes = transportManager.ReadNextDataToSend(
+                registerCallbackIfNoDataAvailable: false,
+                out ClientRemotingDataPriority priority);
+
+            Assert.NotNull(bytes);
+            Assert.NotEmpty(bytes);
+            Assert.Equal(ClientRemotingDataPriority.Default, priority);
+        }
+
+        [Fact]
+        public static void SessionTransportDoesNotDropQueuedDataWhenFragmentSizeChangeIsRejected()
+        {
+            var context = CreateContext(new CustomConnectionInfo());
+            var transportManager = new TestSessionTransportManager(context);
+            var data = CreateTestRemoteDataObject(context.RunspacePoolInstanceId);
+
+            transportManager.QueueDataToSend(data, ClientRemotingDataPriority.Default);
+
+            Assert.Throws<InvalidOperationException>(() => transportManager.SetFragmentSize(64 * 1024));
+
+            byte[] bytes = transportManager.ReadNextDataToSend(
+                registerCallbackIfNoDataAvailable: false,
+                out ClientRemotingDataPriority priority);
+
+            Assert.NotNull(bytes);
+            Assert.NotEmpty(bytes);
+            Assert.Equal(ClientRemotingDataPriority.Default, priority);
+        }
+
+        [Fact]
+        public static void SessionTransportPreservesPendingCallbackWhenFragmentSizeChanges()
+        {
+            var context = CreateContext(new CustomConnectionInfo());
+            var transportManager = new TestSessionTransportManager(context);
+            var data = CreateTestRemoteDataObject(context.RunspacePoolInstanceId);
+            using var dataAvailable = new ManualResetEventSlim();
+            byte[] callbackData = null;
+            ClientRemotingDataPriority callbackPriority = ClientRemotingDataPriority.PromptResponse;
+            transportManager.DataToSendAvailableCallback = (bytes, priority) =>
+            {
+                callbackData = bytes.ToArray();
+                callbackPriority = priority;
+                dataAvailable.Set();
+            };
+
+            Assert.Null(transportManager.ReadNextDataToSend(
+                registerCallbackIfNoDataAvailable: true,
+                out _));
+
+            transportManager.SetFragmentSize(64 * 1024);
+
+            transportManager.QueueDataToSend(data, ClientRemotingDataPriority.Default);
+
+            Assert.True(dataAvailable.Wait(TimeSpan.FromSeconds(5)));
+            Assert.NotNull(callbackData);
+            Assert.NotEmpty(callbackData);
+            Assert.Equal(ClientRemotingDataPriority.Default, callbackPriority);
+        }
+
+        [Fact]
+        public static void SessionTransportPreservesOutboundPromptResponsePriority()
+        {
+            var context = CreateContext(new CustomConnectionInfo());
+            var transportManager = new TestSessionTransportManager(context);
+            var data = CreateTestRemoteDataObject(context.RunspacePoolInstanceId);
+
+            transportManager.QueueDataToSend(data, ClientRemotingDataPriority.PromptResponse);
+
+            byte[] bytes = transportManager.ReadNextDataToSend(
+                registerCallbackIfNoDataAvailable: false,
+                out ClientRemotingDataPriority priority);
+
+            Assert.NotNull(bytes);
+            Assert.NotEmpty(bytes);
+            Assert.Equal(ClientRemotingDataPriority.PromptResponse, priority);
+        }
+
+        [Fact]
+        public static void LoopbackCustomTransportsExchangePsrpFragmentsThroughProtectedApis()
+        {
+            var context = CreateContext(new CustomConnectionInfo());
+            var client = new LoopbackSessionTransportManager(context);
+            var server = new LoopbackSessionTransportManager(context);
+            var data = CreateTestRemoteDataObject(context.RunspacePoolInstanceId);
+            using var dataReceived = new ManualResetEventSlim();
+            RemoteDataObject<PSObject> receivedData = null;
+
+            server.DataReceived += (source, args) =>
+            {
+                receivedData = args.ReceivedData;
+                dataReceived.Set();
+            };
+
+            client.QueueDataToSend(data, ClientRemotingDataPriority.Default);
+            client.PumpOutboundDataTo(server);
+
+            Assert.True(dataReceived.Wait(TimeSpan.FromSeconds(5)));
+            Assert.NotNull(receivedData);
+            Assert.Equal(data.DataType, receivedData.DataType);
+            Assert.Equal(data.RunspacePoolId, receivedData.RunspacePoolId);
+        }
+
+        [Fact]
+        public static void SessionTransportProcessesReceivedDataWithTransportNeutralPriority()
+        {
+            var context = CreateContext(new CustomConnectionInfo());
+            var sender = new TestSessionTransportManager(context);
+            var receiver = new TestSessionTransportManager(context);
+            var data = CreateTestRemoteDataObject(context.RunspacePoolInstanceId);
+            using var dataReceived = new ManualResetEventSlim();
+            RemoteDataObject<PSObject> receivedData = null;
+
+            receiver.DataReceived += (source, args) =>
+            {
+                receivedData = args.ReceivedData;
+                dataReceived.Set();
+            };
+
+            sender.QueueDataToSend(data, ClientRemotingDataPriority.PromptResponse);
+            byte[] bytes = sender.ReadNextDataToSend(
+                registerCallbackIfNoDataAvailable: false,
+                out _);
+
+            receiver.ProcessIncomingData(bytes, ClientRemotingDataPriority.PromptResponse);
+
+            Assert.True(dataReceived.Wait(TimeSpan.FromSeconds(5)));
+            Assert.NotNull(receivedData);
+            Assert.Equal(data.DataType, receivedData.DataType);
+            Assert.Equal(data.RunspacePoolId, receivedData.RunspacePoolId);
+        }
+
+        [Fact]
+        public static void SessionTransportExposesDisconnectAndRetryCapabilities()
+        {
+            var context = CreateContext(new CustomConnectionInfo());
+            var transportManager = new TestSessionTransportManager(context)
+            {
+                DisconnectSupported = true,
+                RetryConnectionTime = 1234,
+            };
+
+            Assert.True(transportManager.GetSupportsDisconnect());
+            Assert.Equal(1234, transportManager.GetMaxRetryConnectionTime());
+        }
+
+        [Fact]
+        public static void CommandTransportContextExposesCommandText()
+        {
+            const string commandText = "Get-Process | Select-Object -First 1";
+            var connectionInfo = new CustomConnectionInfo();
+            var sessionContext = CreateContext(connectionInfo);
+            var sessionTransportManager = new TestSessionTransportManager(sessionContext);
+            using var powerShell = PowerShell.Create();
+            powerShell.AddScript(commandText);
+            using var runspacePool = RunspaceFactory.CreateRunspacePool(
+                minRunspaces: 1,
+                maxRunspaces: 1,
+                connectionInfo: connectionInfo,
+                host: null,
+                typeTable: null,
+                applicationArguments: null);
+            powerShell.RunspacePool = runspacePool;
+            using var remotePowerShell = new ClientRemotePowerShell(powerShell, runspacePool.RemoteRunspacePoolInternal);
+            var commandContext = new ClientCommandTransportCreationContext(
+                connectionInfo,
+                remotePowerShell,
+                noInput: true,
+                sessionTransportManager,
+                new PSRemotingCryptoHelperClient());
+
+            Assert.Equal(commandText, commandContext.CommandText);
+
+            using var commandTransportManager = new TestCommandTransportManager(commandContext);
+            Assert.Equal(commandText, commandTransportManager.GetCommandText());
+        }
+
+        [Fact]
+        public static void CommandTransportInitialDataCanRegisterForFutureCallback()
+        {
+            var connectionInfo = new CustomConnectionInfo();
+            var sessionContext = CreateContext(connectionInfo);
+            var sessionTransportManager = new TestSessionTransportManager(sessionContext);
+            using var powerShell = PowerShell.Create();
+            powerShell.AddScript("Get-Date");
+            using var runspacePool = RunspaceFactory.CreateRunspacePool(
+                minRunspaces: 1,
+                maxRunspaces: 1,
+                connectionInfo: connectionInfo,
+                host: null,
+                typeTable: null,
+                applicationArguments: null);
+            powerShell.RunspacePool = runspacePool;
+            using var remotePowerShell = new ClientRemotePowerShell(powerShell, runspacePool.RemoteRunspacePoolInternal);
+            var commandContext = new ClientCommandTransportCreationContext(
+                connectionInfo,
+                remotePowerShell,
+                noInput: true,
+                sessionTransportManager,
+                new PSRemotingCryptoHelperClient());
+            using var commandTransportManager = new TestCommandTransportManager(commandContext);
+            using var dataAvailable = new ManualResetEventSlim();
+            byte[] callbackData = null;
+            ClientRemotingDataPriority callbackPriority = ClientRemotingDataPriority.PromptResponse;
+            commandTransportManager.DataToSendAvailableCallback = (bytes, priority) =>
+            {
+                callbackData = bytes.ToArray();
+                callbackPriority = priority;
+                dataAvailable.Set();
+            };
+
+            while (commandTransportManager.ReadInitialData(registerCallbackIfNoDataAvailable: false) != null)
+            {
+            }
+
+            Assert.Null(commandTransportManager.ReadInitialData(registerCallbackIfNoDataAvailable: true));
+
+            commandTransportManager.QueueAdditionalInitialData(CreateTestRemoteDataObject(sessionContext.RunspacePoolInstanceId));
+
+            Assert.True(dataAvailable.Wait(TimeSpan.FromSeconds(5)));
+            Assert.NotNull(callbackData);
+            Assert.NotEmpty(callbackData);
+            Assert.Equal(ClientRemotingDataPriority.Default, callbackPriority);
+        }
+
+        [Fact]
+        public static void CommandTransportInitialDataCanBeLoopedBackThroughProtectedApis()
+        {
+            var connectionInfo = new CustomConnectionInfo();
+            var sessionContext = CreateContext(connectionInfo);
+            var sessionTransportManager = new TestSessionTransportManager(sessionContext);
+            var receiver = new LoopbackSessionTransportManager(sessionContext);
+            using var powerShell = PowerShell.Create();
+            powerShell.AddScript("Get-ChildItem");
+            using var runspacePool = RunspaceFactory.CreateRunspacePool(
+                minRunspaces: 1,
+                maxRunspaces: 1,
+                connectionInfo: connectionInfo,
+                host: null,
+                typeTable: null,
+                applicationArguments: null);
+            powerShell.RunspacePool = runspacePool;
+            using var remotePowerShell = new ClientRemotePowerShell(powerShell, runspacePool.RemoteRunspacePoolInternal);
+            var commandContext = new ClientCommandTransportCreationContext(
+                connectionInfo,
+                remotePowerShell,
+                noInput: true,
+                sessionTransportManager,
+                new PSRemotingCryptoHelperClient());
+            using var commandTransportManager = new TestCommandTransportManager(commandContext);
+            using var dataReceived = new ManualResetEventSlim();
+            RemoteDataObject<PSObject> receivedData = null;
+
+            receiver.DataReceived += (source, args) =>
+            {
+                receivedData = args.ReceivedData;
+                dataReceived.Set();
+            };
+
+            byte[] bytes = commandTransportManager.ReadInitialData(registerCallbackIfNoDataAvailable: false);
+            Assert.NotNull(bytes);
+            Assert.NotEmpty(bytes);
+
+            receiver.ProcessIncomingData(bytes, ClientRemotingDataPriority.Default);
+
+            Assert.True(dataReceived.Wait(TimeSpan.FromSeconds(5)));
+            Assert.NotNull(receivedData);
+            Assert.Equal(RemotingDataType.CreatePowerShell, receivedData.DataType);
+            Assert.Equal(runspacePool.InstanceId, receivedData.RunspacePoolId);
+        }
+
+        [Fact]
+        public static void SessionTransportCanReportLifecycleEvents()
+        {
+            var context = CreateContext(new CustomConnectionInfo());
+            var transportManager = new TestSessionTransportManager(context);
+            int connectCount = 0;
+            int disconnectCount = 0;
+            int reconnectCount = 0;
+            int readyForDisconnectCount = 0;
+            int delayStreamProcessedCount = 0;
+            ConnectionStatus? connectionStatus = null;
+            using var robustNotificationReceived = new ManualResetEventSlim();
+
+            transportManager.ConnectCompleted += (source, args) => connectCount++;
+            transportManager.DisconnectCompleted += (source, args) => disconnectCount++;
+            transportManager.ReconnectCompleted += (source, args) => reconnectCount++;
+            transportManager.ReadyForDisconnect += (source, args) => readyForDisconnectCount++;
+            transportManager.DelayStreamRequestProcessed += (source, args) => delayStreamProcessedCount++;
+            transportManager.RobustConnectionNotification += (source, args) =>
+            {
+                connectionStatus = args.Notification;
+                robustNotificationReceived.Set();
+            };
+
+            transportManager.ReportLifecycleEventsForTest();
+
+            Assert.Equal(1, connectCount);
+            Assert.Equal(1, disconnectCount);
+            Assert.Equal(1, reconnectCount);
+            Assert.Equal(1, readyForDisconnectCount);
+            Assert.Equal(1, delayStreamProcessedCount);
+            Assert.True(robustNotificationReceived.Wait(TimeSpan.FromSeconds(5)));
+            Assert.Equal(ConnectionStatus.ConnectionRetryAttempt, connectionStatus);
+        }
+
+        private static ClientRemotingTransportCreationContext CreateContext(RunspaceConnectionInfo connectionInfo)
+        {
+            return new ClientRemotingTransportCreationContext(
+                Guid.NewGuid(),
+                "test-session",
+                connectionInfo,
+                new PSRemotingCryptoHelperClient());
+        }
+
+        private static RemoteDataObject<PSObject> CreateTestRemoteDataObject(Guid runspacePoolInstanceId)
+        {
+            return RemoteDataObject<PSObject>.CreateFrom(
+                RemotingDestination.Client,
+                RemotingDataType.ApplicationPrivateData,
+                runspacePoolInstanceId,
+                Guid.Empty,
+                PSObject.AsPSObject(new PSPrimitiveDictionary()));
+        }
+
+        private sealed class TestProvider : IClientRemotingTransportProvider
+        {
+            private readonly Func<RunspaceConnectionInfo, bool> _canCreateTransport;
+
+            internal TestProvider(Func<RunspaceConnectionInfo, bool> canCreateTransport)
+            {
+                _canCreateTransport = canCreateTransport;
+            }
+
+            internal int CreateSessionTransportCount { get; private set; }
+
+            public bool CanCreateTransport(RunspaceConnectionInfo connectionInfo)
+            {
+                return _canCreateTransport(connectionInfo);
+            }
+
+            public BaseClientSessionTransportManager CreateSessionTransport(ClientRemotingTransportCreationContext context)
+            {
+                CreateSessionTransportCount++;
+                return new TestSessionTransportManager(context);
+            }
+        }
+
+        private sealed class NullTransportProvider : IClientRemotingTransportProvider
+        {
+            public bool CanCreateTransport(RunspaceConnectionInfo connectionInfo)
+            {
+                return true;
+            }
+
+            public BaseClientSessionTransportManager CreateSessionTransport(ClientRemotingTransportCreationContext context)
+            {
+                return null;
+            }
+        }
+
+        private class PassiveConnectionInfo : RunspaceConnectionInfo
+        {
+            public override string ComputerName { get; set; } = "passive";
+
+            public override PSCredential Credential { get; set; }
+
+            public override AuthenticationMechanism AuthenticationMechanism { get; set; }
+
+            public override string CertificateThumbprint { get; set; }
+
+            public override RunspaceConnectionInfo Clone()
+            {
+                var clone = new PassiveConnectionInfo();
+                CopyClientTransportOptionsTo(clone);
+                return clone;
+            }
+        }
+
+        private sealed class CustomConnectionInfo : PassiveConnectionInfo
+        {
+            protected internal override bool CanCreateClientRemotingTransport => true;
+
+            public override BaseClientSessionTransportManager CreateClientSessionTransportManager(
+                ClientRemotingTransportCreationContext context)
+            {
+                return new TestSessionTransportManager(context);
+            }
+
+            public override RunspaceConnectionInfo Clone()
+            {
+                var clone = new CustomConnectionInfo();
+                CopyClientTransportOptionsTo(clone);
+                return clone;
+            }
+        }
+
+        private sealed class NullCustomConnectionInfo : PassiveConnectionInfo
+        {
+            protected internal override bool CanCreateClientRemotingTransport => true;
+
+            public override BaseClientSessionTransportManager CreateClientSessionTransportManager(
+                ClientRemotingTransportCreationContext context)
+            {
+                return null;
+            }
+        }
+
+        private sealed class TestSessionTransportManager : BaseClientSessionTransportManager
+        {
+            internal TestSessionTransportManager(ClientRemotingTransportCreationContext context)
+                : base(context)
+            {
+            }
+
+            public override void CreateAsync()
+            {
+            }
+
+            protected internal override void ConnectAsync()
+            {
+            }
+
+            internal bool DisconnectSupported { get; set; }
+
+            protected internal override bool SupportsDisconnect => DisconnectSupported;
+
+            internal int RetryConnectionTime { get; set; }
+
+            protected internal override int MaxRetryConnectionTime => RetryConnectionTime;
+
+            internal Action<ReadOnlyMemory<byte>, ClientRemotingDataPriority> DataToSendAvailableCallback { get; set; }
+
+            protected override void OnDataToSendAvailable(
+                ReadOnlyMemory<byte> data,
+                ClientRemotingDataPriority priority)
+            {
+                DataToSendAvailableCallback?.Invoke(data, priority);
+            }
+
+            internal void QueueDataToSend(
+                RemoteDataObject<PSObject> data,
+                ClientRemotingDataPriority priority)
+            {
+                DataToBeSentCollection.Add(
+                    data,
+                    priority == ClientRemotingDataPriority.PromptResponse
+                        ? DataPriorityType.PromptResponse
+                        : DataPriorityType.Default);
+            }
+
+            internal byte[] ReadNextDataToSend(
+                bool registerCallbackIfNoDataAvailable,
+                out ClientRemotingDataPriority priority)
+            {
+                return ReadDataToSend(registerCallbackIfNoDataAvailable, out priority);
+            }
+
+            internal void ProcessIncomingData(byte[] data, ClientRemotingDataPriority priority)
+            {
+                ProcessReceivedData(data, priority);
+            }
+
+            internal void ReportInvalidRobustConnectionNotification()
+            {
+                ReportRobustConnectionNotification((ConnectionStatus)99);
+            }
+
+            internal void ReportLifecycleEventsForTest()
+            {
+                CompleteConnect();
+                CompleteDisconnect();
+                CompleteReconnect();
+                CompleteReadyForDisconnect();
+                CompleteDelayStreamProcessed();
+                ReportRobustConnectionNotification(ConnectionStatus.ConnectionRetryAttempt);
+            }
+
+            internal Guid GetRunspacePoolInstanceId()
+            {
+                return RunspacePoolInstanceId;
+            }
+
+            internal RunspaceConnectionInfo GetTransportConnectionInfo()
+            {
+                return TransportConnectionInfo;
+            }
+
+            internal int GetFragmentSize()
+            {
+                return FragmentSize;
+            }
+
+            internal void SetFragmentSize(int fragmentSize)
+            {
+                FragmentSize = fragmentSize;
+            }
+
+            internal bool GetSupportsDisconnect()
+            {
+                return SupportsDisconnect;
+            }
+
+            internal int GetMaxRetryConnectionTime()
+            {
+                return MaxRetryConnectionTime;
+            }
+        }
+
+        private sealed class LoopbackSessionTransportManager : BaseClientSessionTransportManager
+        {
+            internal LoopbackSessionTransportManager(ClientRemotingTransportCreationContext context)
+                : base(context)
+            {
+            }
+
+            public override void CreateAsync()
+            {
+            }
+
+            protected internal override void ConnectAsync()
+            {
+            }
+
+            internal void QueueDataToSend(
+                RemoteDataObject<PSObject> data,
+                ClientRemotingDataPriority priority)
+            {
+                DataToBeSentCollection.Add(
+                    data,
+                    priority == ClientRemotingDataPriority.PromptResponse
+                        ? DataPriorityType.PromptResponse
+                        : DataPriorityType.Default);
+            }
+
+            internal void PumpOutboundDataTo(LoopbackSessionTransportManager peer)
+            {
+                byte[] data;
+                while ((data = ReadDataToSend(registerCallbackIfNoDataAvailable: false, out ClientRemotingDataPriority priority)) != null)
+                {
+                    peer.ProcessReceivedData(data, priority);
+                }
+            }
+
+            internal void ProcessIncomingData(byte[] data, ClientRemotingDataPriority priority)
+            {
+                ProcessReceivedData(data, priority);
+            }
+        }
+
+        private sealed class TestCommandTransportManager : BaseClientCommandTransportManager
+        {
+            internal TestCommandTransportManager(ClientCommandTransportCreationContext context)
+                : base(context)
+            {
+            }
+
+            public override void CreateAsync()
+            {
+            }
+
+            protected internal override void ConnectAsync()
+            {
+            }
+
+            internal Action<ReadOnlyMemory<byte>, ClientRemotingDataPriority> DataToSendAvailableCallback { get; set; }
+
+            protected override void OnDataToSendAvailable(
+                ReadOnlyMemory<byte> data,
+                ClientRemotingDataPriority priority)
+            {
+                DataToSendAvailableCallback?.Invoke(data, priority);
+            }
+
+            internal string GetCommandText()
+            {
+                return CommandText;
+            }
+
+            internal byte[] ReadInitialData(bool registerCallbackIfNoDataAvailable)
+            {
+                return ReadInitialCommandData(registerCallbackIfNoDataAvailable);
+            }
+
+            internal void QueueAdditionalInitialData(RemoteDataObject<PSObject> data)
+            {
+                Fragmentor.Fragment<PSObject>(data, serializedPipeline);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add a client remoting transport provider registry and creation contexts for custom session and command transports.
- Allow opt-in replacement of built-in remoting transports, including WSMan-backed connection info, while preserving PowerShell-owned PSRP serialization, fragmentation, streams, host calls, and remoting crypto.
- Add client-only transport options on session/connection info and wire provider-backed transport creation through runspace/remoting setup.
- Expose transport-neutral protected APIs for outbound/inbound PSRP fragments, priorities, lifecycle completion, disconnect/reconnect capability, redirection, robust connection notifications, and command text.
- Harden send-queue/fragment-size handling and validate extension-point inputs and null transport factory returns.
- Add focused xUnit coverage, including loopback PSRP fragment flow through custom transport APIs.

## Validation
- `dotnet test .\test\xUnit\xUnit.tests.csproj --configuration Debug --framework net10.0 --filter "FullyQualifiedName~ClientRemotingTransportProviderTests" --nologo --verbosity minimal /p:ReleaseTag=7.6.3 -m:1`
- `pwsh -NoProfile -Command "Import-Module .\build.psm1; Start-PSBuild -SMAOnly -ReleaseTag v7.6.3"`
- `pwsh -NoProfile -Command "Import-Module .\build.psm1; Start-PSBuild -ReleaseTag v7.6.3"`