### PR TITLE
Add PowerShell vendor metadata

### DIFF
--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -141,6 +141,7 @@
   <PropertyGroup>
     <Product>PowerShell</Product>
     <Company>Microsoft Corporation</Company>
+    <PowerShellVendor Condition="'$(PowerShellVendor)' == ''">Microsoft</PowerShellVendor>
     <Copyright>(c) Microsoft Corporation.</Copyright>
     <AssemblyTitle>PowerShell 7</AssemblyTitle>
 

--- a/src/System.Management.Automation/SourceGenerators/PSVersionInfoGenerator/PSVersionInfoGenerator.cs
+++ b/src/System.Management.Automation/SourceGenerators/PSVersionInfoGenerator/PSVersionInfoGenerator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Text;
 using Microsoft.CodeAnalysis;
 
 namespace SMA
@@ -25,6 +26,7 @@ namespace SMA
                     provider.GlobalOptions.TryGetValue("build_property.ProductVersion", out var productVersion);
                     provider.GlobalOptions.TryGetValue("build_property.PSCoreBuildVersion", out var mainVersion);
                     provider.GlobalOptions.TryGetValue("build_property.PowerShellVersion", out var gitDescribe);
+                    provider.GlobalOptions.TryGetValue("build_property.PowerShellVendor", out var vendor);
                     provider.GlobalOptions.TryGetValue("build_property.ReleaseTag", out var releaseTag);
 
                     BuildOptions options = new()
@@ -32,6 +34,7 @@ namespace SMA
                         ProductVersion = productVersion ?? string.Empty,
                         MainVersion = mainVersion ?? string.Empty,
                         GitDescribe = gitDescribe ?? string.Empty,
+                        Vendor = vendor ?? string.Empty,
                         ReleaseTag = releaseTag ?? string.Empty
                     };
 
@@ -52,12 +55,13 @@ namespace SMA
                     string result = string.Format(
                         CultureInfo.InvariantCulture,
                         SourceTemplate,
-                        buildOptions.ProductVersion,
-                        gitCommitId,
+                        EscapeStringLiteral(buildOptions.ProductVersion),
+                        EscapeStringLiteral(gitCommitId),
                         versions.major,
                         versions.minor,
                         versions.patch,
-                        versions.preReleaseLabel);
+                        EscapeStringLiteral(versions.preReleaseLabel),
+                        EscapeStringLiteral(buildOptions.Vendor));
 
                     // We must use specific file name suffix (*.g.cs,*.g, *.i.cs, *.generated.cs, *.designer.cs)
                     // so that Roslyn analyzers skip the file.
@@ -70,6 +74,7 @@ namespace SMA
             public string ProductVersion;
             public string MainVersion;
             public string GitDescribe;
+            public string Vendor;
             public string ReleaseTag;
         }
 
@@ -97,6 +102,10 @@ namespace System.Management.Automation
         //  - when built from a preview release tag: GitCommitId = '7.3.0-preview.8'
         //  - when built from a stable release tag:  GitCommitId = '7.3.0'
         internal const string GitCommitId = ""{1}"";
+
+        // The vendor of this PowerShell distribution.
+        // Defined in 'PowerShell.Common.props' as 'PowerShellVendor'.
+        internal const string Vendor = ""{6}"";
 
         // The PowerShell version components.
         // The version string is defined in 'PowerShell.Common.props' as 'PSCoreBuildVersion',
@@ -131,6 +140,62 @@ namespace System.Management.Automation
             int patch = int.Parse(mainVersion.Substring(minorEnd + 1), NumberStyles.Integer, CultureInfo.InvariantCulture);
 
             return (major, minor, patch, preReleaseLabel);
+        }
+
+        private static string EscapeStringLiteral(string value)
+        {
+            var builder = new StringBuilder(value.Length);
+
+            foreach (char c in value)
+            {
+                switch (c)
+                {
+                    case '\"':
+                        builder.Append("\\\"");
+                        break;
+                    case '\\':
+                        builder.Append("\\\\");
+                        break;
+                    case '\0':
+                        builder.Append("\\0");
+                        break;
+                    case '\a':
+                        builder.Append("\\a");
+                        break;
+                    case '\b':
+                        builder.Append("\\b");
+                        break;
+                    case '\f':
+                        builder.Append("\\f");
+                        break;
+                    case '\n':
+                        builder.Append("\\n");
+                        break;
+                    case '\r':
+                        builder.Append("\\r");
+                        break;
+                    case '\t':
+                        builder.Append("\\t");
+                        break;
+                    case '\v':
+                        builder.Append("\\v");
+                        break;
+                    default:
+                        if (char.IsControl(c))
+                        {
+                            builder.Append("\\u");
+                            builder.Append(((int)c).ToString("x4", CultureInfo.InvariantCulture));
+                        }
+                        else
+                        {
+                            builder.Append(c);
+                        }
+
+                        break;
+                }
+            }
+
+            return builder.ToString();
         }
     }
 }

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -17,6 +17,7 @@
     <CompilerVisibleProperty Include="ProductVersion" />
     <CompilerVisibleProperty Include="PSCoreBuildVersion" />
     <CompilerVisibleProperty Include="PowerShellVersion" />
+    <CompilerVisibleProperty Include="PowerShellVendor" />
     <CompilerVisibleProperty Include="ReleaseTag" />
 
     <ProjectReference Include="SourceGenerators\PSVersionInfoGenerator\PSVersionInfoGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -32,6 +32,7 @@ namespace System.Management.Automation
         internal const string PSRemotingProtocolVersionName = "PSRemotingProtocolVersion";
         internal const string PSVersionName = "PSVersion";
         internal const string PSEditionName = "PSEdition";
+        internal const string PSVendorName = "Vendor";
         internal const string PSGitCommitIdName = "GitCommitId";
         internal const string PSCompatibleVersionsName = "PSCompatibleVersions";
         internal const string PSPlatformName = "Platform";
@@ -46,6 +47,7 @@ namespace System.Management.Automation
 
                 internal const string ProductVersion;
                 internal const string GitCommitId;
+                internal const string Vendor;
 
                 private const int Version_Major
                 private const int Version_Minor;
@@ -92,6 +94,7 @@ namespace System.Management.Automation
 
             s_psVersionTable[PSVersionName] = s_psSemVersion;
             s_psVersionTable[PSEditionName] = PSEditionValue;
+            s_psVersionTable[PSVendorName] = Vendor;
             s_psVersionTable[PSGitCommitIdName] = GitCommitId;
             s_psVersionTable[PSCompatibleVersionsName] = new Version[] { s_psV1Version, s_psV2Version, s_psV3Version, s_psV4Version, s_psV5Version, s_psV51Version, s_psV6Version, s_psV7Version };
             s_psVersionTable[SerializationVersionName] = new Version(InternalSerializer.DefaultVersion);

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -26,12 +26,13 @@ Describe "PSVersionTable" -Tags "CI" {
     }
 
     It "Should have version table entries" {
-       $PSVersionTable.Count | Should -Be 9
+       $PSVersionTable.Count | Should -Be 10
     }
 
     It "Should have the right version table entries" {
        $PSVersionTable.ContainsKey("PSVersion")                 | Should -BeTrue
        $PSVersionTable.ContainsKey("PSEdition")                 | Should -BeTrue
+       $PSVersionTable.ContainsKey("Vendor")                    | Should -BeTrue
        $PSVersionTable.ContainsKey("WSManStackVersion")         | Should -BeTrue
        $PSVersionTable.ContainsKey("SerializationVersion")      | Should -BeTrue
        $PSVersionTable.ContainsKey("PSCompatibleVersions")      | Should -BeTrue
@@ -54,6 +55,11 @@ Describe "PSVersionTable" -Tags "CI" {
        $PSVersionTable.GitCommitId | Should -Match $expectedGitCommitIdPattern
        $PSVersionTable.GitCommitId | Should -Not -Match $unexpectectGitCommitIdPattern
        $PSVersionTable.GitCommitId | Should -BeExactly $rawGitCommitId
+    }
+
+    It "Vendor property" {
+       $PSVersionTable.Vendor | Should -BeOfType System.String
+       $PSVersionTable.Vendor | Should -Not -BeNullOrEmpty
     }
 
     It "Should have the correct platform info" {


### PR DESCRIPTION
## Summary
- add a `PowerShellVendor` MSBuild property defaulting to `Microsoft`
- emit the vendor through `PSVersionInfoGenerator` and expose it as `$PSVersionTable.Vendor`
- update `PSVersionTable` tests for the new entry without assuming a specific custom vendor

## Validation
- `Import-Module .\build.psm1; Start-PSBuild -Configuration Debug -PSModuleRestore -UseNuGetOrg -ReleaseTag v7.6.3`
- `$env:PowerShellVendor = 'Devolutions'; Import-Module .\build.psm1; Start-PSBuild -Configuration Debug -ReleaseTag v7.6.3 -SMAOnly -UseNuGetOrg`
- `Import-Module .\build.psm1; Start-PSBuild -Configuration Debug -ReleaseTag v7.6.3 -SMAOnly -UseNuGetOrg`
- `Import-Module .\build.psm1; Start-PSPester -Path .\test\powershell\Host\PSVersionTable.Tests.ps1 -ThrowOnFailure -SkipTestToolBuild -BinDir .\src\powershell-win-core\bin\Debug\net10.0\win7-x64\publish -OutputFile .\pester-vendor-tests.xml`