### PR TITLE
Fix PowerShell SDK apphost layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Applications that need architecture-specific apphost launchers in a native asset
 </PropertyGroup>
 ```
 
-This copies a minimal native launcher to `runtimes/<rid>/native/pwsh.exe` (or `pwsh` on Unix) for each selected RID. The launcher loads `../../../pwsh.dll`, so `pwsh.dll`, `pwsh.runtimeconfig.json`, PowerShell runtime assemblies, built-in modules, and required RID-specific runtime library dependencies are copied once to the app output root and shared with the consuming executable. Leave `PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers` empty to copy every runtime-native launcher included in the package, or set it to a semicolon-delimited RID list. Unknown RIDs fail the build.
+This copies a minimal native launcher to `runtimes/<rid>/native/pwsh.exe` (or `pwsh` on Unix) for each selected RID. The launcher loads `../../../pwsh.dll`, so `pwsh.dll`, `pwsh.runtimeconfig.json`, PowerShell runtime assemblies, built-in modules, and required RID-specific runtime library dependencies are copied to the app output root for external `pwsh` support. The original NuGet `runtimes/<group>/lib/<tfm>` payload is also preserved so the application `.deps.json` can resolve `System.Management.Automation` and built-in modules for in-process hosting. Leave `PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers` empty to copy every runtime-native launcher included in the package, or set it to a semicolon-delimited RID list. Unknown RIDs fail the build.
 
 The source-built PowerShell runtime is patched so out-of-process jobs can use the selected runtime-native launcher when `$PSHOME/pwsh.exe` is not present. This lets `Start-Job` work in bundled-host scenarios that copy `pwsh.exe` under `runtimes/<rid>/native` instead of the app root.
 
@@ -221,6 +221,7 @@ Use `PowerShellSDKCopyPhases` to decide where opted-in payloads are copied. The 
 | `PowerShellSDKAppHostLayout` | `None` | `None`, `Root`, `RuntimeNative`, `Both` | Selects the apphost file layout. |
 | `PowerShellSDKAppHostImplementation` | `Auto` | `Auto`, `MultiPwsh`, `DotNet` | Selects the apphost executable implementation when the requested layout/package assets support it. Current package assets support `MultiPwsh` for `Root` and `RuntimeNative`. |
 | `PowerShellSDKAppHostRuntimeIdentifier` | empty | RID | Overrides root apphost RID selection; otherwise `$(RuntimeIdentifier)` then `$(NETCoreSdkRuntimeIdentifier)` are used. |
+| `PowerShellSDKAppHostTargetFramework` | empty | TFM | Overrides root apphost payload TFM lookup; normally platform-specific TFMs such as `net10.0-windows10.0.19041` normalize to the package TFM `net10.0`. |
 | `PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers` | empty | RID list | Semicolon-delimited runtime-native launcher RIDs; empty selects all packaged RIDs. |
 | `PowerShellSDKRuntimeNativeSharedPayloadRuntimeIdentifier` | empty | RID | Overrides the shared app-root PowerShell payload RID. Otherwise it follows `$(RuntimeIdentifier)`, `$(NETCoreSdkRuntimeIdentifier)`, then `PowerShellSDKAppHostRuntimeIdentifier`. |
 | `PowerShellSDKRuntimeNativeSharedPayloadTargetFramework` | empty | TFM | Overrides shared payload TFM lookup; normally platform-specific TFMs such as `net10.0-windows10.0.19041` normalize to the package TFM `net10.0`. |

--- a/eng/Microsoft.PowerShell.SDK.targets
+++ b/eng/Microsoft.PowerShell.SDK.targets
@@ -196,35 +196,6 @@
     <ItemGroup>
       <NativeCopyLocalItems Remove="@(NativeCopyLocalItems)"
                             Condition="'%(NativeCopyLocalItems.NuGetPackageId)' == 'Devolutions.PowerShell.SDK' and $([System.String]::Copy('%(NativeCopyLocalItems.PathInPackage)').Contains('/native/'))" />
-      <RuntimeCopyLocalItems Condition="'$(_PowerShellSDKRuntimeNativeCopyToOutputEnabled)' == 'true' and '%(RuntimeCopyLocalItems.NuGetPackageId)' == 'Devolutions.PowerShell.SDK' and ($([System.String]::Copy('%(RuntimeCopyLocalItems.PathInPackage)').Contains('/lib/')) or $([System.String]::Copy('%(RuntimeCopyLocalItems.DestinationSubDirectory)').Contains('\lib\')) or $([System.String]::Copy('%(RuntimeCopyLocalItems.DestinationSubDirectory)').Contains('/lib/')))">
-        <DestinationSubDirectory></DestinationSubDirectory>
-      </RuntimeCopyLocalItems>
-      <RuntimeTargetsCopyLocalItems Condition="'$(_PowerShellSDKRuntimeNativeCopyToOutputEnabled)' == 'true' and '%(RuntimeTargetsCopyLocalItems.NuGetPackageId)' == 'Devolutions.PowerShell.SDK' and ($([System.String]::Copy('%(RuntimeTargetsCopyLocalItems.PathInPackage)').Contains('/lib/')) or $([System.String]::Copy('%(RuntimeTargetsCopyLocalItems.DestinationSubDirectory)').Contains('\lib\')) or $([System.String]::Copy('%(RuntimeTargetsCopyLocalItems.DestinationSubDirectory)').Contains('/lib/')))">
-        <DestinationSubDirectory></DestinationSubDirectory>
-      </RuntimeTargetsCopyLocalItems>
-      <_ContentFilesToPreprocess Remove="@(_ContentFilesToPreprocess)"
-                                 Condition="'$(_PowerShellSDKRuntimeNativeCopyToOutputEnabled)' == 'true' and '%(_ContentFilesToPreprocess.NuGetPackageId)' == 'Devolutions.PowerShell.SDK' and ($([System.String]::Copy('%(_ContentFilesToPreprocess.PathInPackage)').Contains('/runtimes/')) or $([System.String]::Copy('%(_ContentFilesToPreprocess.OutputPath)').Contains('runtimes\')) or $([System.String]::Copy('%(_ContentFilesToPreprocess.OutputPath)').Contains('runtimes/')))" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="_PowerShellSDKRemoveAutomaticSharedPayloadContentCopyItems"
-          AfterTargets="RunProduceContentAssets"
-          BeforeTargets="ResolveLockFileCopyLocalFiles"
-          Condition="'$(_PowerShellSDKRuntimeNativeCopyToOutputEnabled)' == 'true'">
-    <ItemGroup>
-      <_ContentCopyLocalItems Remove="@(_ContentCopyLocalItems)"
-                              Condition="'%(_ContentCopyLocalItems.NuGetPackageId)' == 'Devolutions.PowerShell.SDK' and ($([System.String]::Copy('%(_ContentCopyLocalItems.PathInPackage)').Contains('/runtimes/')) or $([System.String]::Copy('%(_ContentCopyLocalItems.TargetPath)').Contains('runtimes\')) or $([System.String]::Copy('%(_ContentCopyLocalItems.TargetPath)').Contains('runtimes/')))" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="_PowerShellSDKRemoveAutomaticSharedPayloadContentItems"
-          BeforeTargets="GetCopyToOutputDirectoryItems;_GetCopyToOutputDirectoryItemsFromThisProject;GetCopyToPublishDirectoryItems"
-          Condition="'$(_PowerShellSDKRuntimeNativeCopyToOutputEnabled)' == 'true' or '$(_PowerShellSDKRuntimeNativeCopyToPublishEnabled)' == 'true'">
-    <ItemGroup>
-      <None Remove="@(None)"
-            Condition="'%(None.NuGetPackageId)' == 'Devolutions.PowerShell.SDK' and ($([System.String]::Copy('%(None.TargetPath)').Contains('runtimes\')) or $([System.String]::Copy('%(None.TargetPath)').Contains('runtimes/'))) and ($([System.String]::Copy('%(None.TargetPath)').Contains('\Modules\')) or $([System.String]::Copy('%(None.TargetPath)').Contains('/Modules/')))" />
-      <Content Remove="@(Content)"
-               Condition="'%(Content.NuGetPackageId)' == 'Devolutions.PowerShell.SDK' and ($([System.String]::Copy('%(Content.TargetPath)').Contains('runtimes\')) or $([System.String]::Copy('%(Content.TargetPath)').Contains('runtimes/'))) and ($([System.String]::Copy('%(Content.TargetPath)').Contains('\Modules\')) or $([System.String]::Copy('%(Content.TargetPath)').Contains('/Modules/')))" />
     </ItemGroup>
   </Target>
 
@@ -256,20 +227,24 @@
            Text="PowerShellSDKAppHostLayout includes Root, but no runtime identifier is available. Set RuntimeIdentifier or PowerShellSDKAppHostRuntimeIdentifier." />
 
     <PropertyGroup>
+      <_PowerShellSDKAppHostTargetFramework Condition="'$(PowerShellSDKAppHostTargetFramework)' != ''">$(PowerShellSDKAppHostTargetFramework)</_PowerShellSDKAppHostTargetFramework>
+      <_PowerShellSDKAppHostTargetFramework Condition="'$(_PowerShellSDKAppHostTargetFramework)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(TargetFrameworkVersion)' != ''">net$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworkVersion)', '^v', ''))</_PowerShellSDKAppHostTargetFramework>
+      <_PowerShellSDKAppHostTargetFramework Condition="'$(_PowerShellSDKAppHostTargetFramework)' == ''">$(TargetFramework)</_PowerShellSDKAppHostTargetFramework>
       <_PowerShellSDKAppHostSourceDir>$(MSBuildThisFileDirectory)../tools/apphost/$(_PowerShellSDKAppHostRid)/</_PowerShellSDKAppHostSourceDir>
-      <_PowerShellSDKModuleSourceDir>$(MSBuildThisFileDirectory)../contentFiles/any/any/runtimes/$(_PowerShellSDKAppHostRuntimeGroup)/lib/$(TargetFramework)/Modules/</_PowerShellSDKModuleSourceDir>
-      <_PowerShellSDKAppHostRuntimeSourceDir>$(MSBuildThisFileDirectory)../runtimes/$(_PowerShellSDKAppHostRuntimeGroup)/lib/$(TargetFramework)/</_PowerShellSDKAppHostRuntimeSourceDir>
-      <_PowerShellSDKAppHostLocalizedResourceSourceDir>$(MSBuildThisFileDirectory)localized-resources/$(_PowerShellSDKAppHostRuntimeGroup)/lib/$(TargetFramework)/</_PowerShellSDKAppHostLocalizedResourceSourceDir>
+      <_PowerShellSDKModuleSourceDir>$(MSBuildThisFileDirectory)../contentFiles/any/any/runtimes/$(_PowerShellSDKAppHostRuntimeGroup)/lib/$(_PowerShellSDKAppHostTargetFramework)/Modules/</_PowerShellSDKModuleSourceDir>
+      <_PowerShellSDKAppHostRuntimeSourceDir>$(MSBuildThisFileDirectory)../runtimes/$(_PowerShellSDKAppHostRuntimeGroup)/lib/$(_PowerShellSDKAppHostTargetFramework)/</_PowerShellSDKAppHostRuntimeSourceDir>
+      <_PowerShellSDKAppHostLocalizedResourceSourceDir>$(MSBuildThisFileDirectory)localized-resources/$(_PowerShellSDKAppHostRuntimeGroup)/lib/$(_PowerShellSDKAppHostTargetFramework)/</_PowerShellSDKAppHostLocalizedResourceSourceDir>
     </PropertyGroup>
 
     <Error Condition="!Exists('$(_PowerShellSDKAppHostSourceDir)')"
            Text="PowerShellSDKAppHostLayout includes Root, but this PowerShell SDK package does not include apphost files for '$(_PowerShellSDKAppHostRid)'. Set PowerShellSDKAppHostRuntimeIdentifier to a supported runtime identifier." />
     <Error Condition="!Exists('$(_PowerShellSDKModuleSourceDir)')"
-           Text="PowerShellSDKAppHostLayout includes Root, but this PowerShell SDK package does not include module files for runtime group '$(_PowerShellSDKAppHostRuntimeGroup)' and target framework '$(TargetFramework)'." />
+           Text="PowerShellSDKAppHostLayout includes Root, but this PowerShell SDK package does not include module files for runtime group '$(_PowerShellSDKAppHostRuntimeGroup)' and apphost target framework '$(_PowerShellSDKAppHostTargetFramework)'." />
 
     <ItemGroup>
       <_PowerShellSDKAppHostFile Include="$(_PowerShellSDKAppHostSourceDir)**/*" />
       <_PowerShellSDKModuleFile Include="$(_PowerShellSDKModuleSourceDir)**/*" />
+      <_PowerShellSDKAppHostRuntimeFile Include="$(_PowerShellSDKAppHostRuntimeSourceDir)*.dll;$(_PowerShellSDKAppHostRuntimeSourceDir)*.xml" />
       <_PowerShellSDKAppHostCompanionFile Include="$(_PowerShellSDKAppHostRuntimeSourceDir)*.config" />
       <_PowerShellSDKAppHostLocalizedResourceFile Include="$(_PowerShellSDKAppHostLocalizedResourceSourceDir)**/*"
                                                   Condition="Exists('$(_PowerShellSDKAppHostLocalizedResourceSourceDir)')" />
@@ -432,9 +407,21 @@
     <Copy SourceFiles="@(_PowerShellSDKAppHostFile)"
           DestinationFiles="@(_PowerShellSDKAppHostFile->'$(OutDir)%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(_PowerShellSDKAppHostRuntimeFile)"
+          DestinationFiles="@(_PowerShellSDKAppHostRuntimeFile->'$(OutDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(_PowerShellSDKModuleFile)"
           DestinationFiles="@(_PowerShellSDKModuleFile->'$(OutDir)Modules/%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
+    <ItemGroup>
+      <_PowerShellSDKAppHostDependencySourceFile Include="$(OutDir)runtimes/$(_PowerShellSDKAppHostRid)/lib/**/*.dll" />
+      <_PowerShellSDKAppHostDependencyFile Include="@(_PowerShellSDKAppHostDependencySourceFile)"
+                                           Condition="!Exists('$(OutDir)%(_PowerShellSDKAppHostDependencySourceFile.Filename)%(_PowerShellSDKAppHostDependencySourceFile.Extension)')" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_PowerShellSDKAppHostDependencyFile)"
+          DestinationFolder="$(OutDir)"
+          SkipUnchangedFiles="true"
+          Condition="'@(_PowerShellSDKAppHostDependencyFile)' != ''" />
     <Exec Command="chmod +x &quot;$(OutDir)pwsh&quot;"
           Condition="'$(OS)' != 'Windows_NT' and Exists('$(OutDir)pwsh')" />
   </Target>
@@ -464,13 +451,6 @@
           DependsOnTargets="_PowerShellSDKResolveRuntimeNativeAppHosts"
           AfterTargets="CopyFilesToOutputDirectory"
           Condition="'$(_PowerShellSDKRuntimeNativeCopyToOutputEnabled)' == 'true'">
-    <ItemGroup>
-      <_PowerShellSDKAutomaticSharedOutputPayloadFile Include="$(OutDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/*.dll;$(OutDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/*.xml;$(OutDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/*.config" />
-    </ItemGroup>
-    <Delete Files="@(_PowerShellSDKAutomaticSharedOutputPayloadFile)"
-            Condition="'@(_PowerShellSDKAutomaticSharedOutputPayloadFile)' != ''" />
-    <RemoveDir Directories="$(OutDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/Modules"
-               Condition="Exists('$(OutDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/Modules')" />
     <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeSharedRuntimeFile)"
           DestinationFiles="@(_PowerShellSDKRuntimeNativeSharedRuntimeFile->'$(OutDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
@@ -479,6 +459,16 @@
           SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeSharedModuleFile)"
           DestinationFiles="@(_PowerShellSDKRuntimeNativeSharedModuleFile->'$(OutDir)Modules/%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeSharedRuntimeFile)"
+          DestinationFiles="@(_PowerShellSDKRuntimeNativeSharedRuntimeFile->'$(OutDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeSharedCompanionFile)"
+          DestinationFiles="@(_PowerShellSDKRuntimeNativeSharedCompanionFile->'$(OutDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true"
+          Condition="'@(_PowerShellSDKRuntimeNativeSharedCompanionFile)' != ''" />
+    <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeSharedModuleFile)"
+          DestinationFiles="@(_PowerShellSDKRuntimeNativeSharedModuleFile->'$(OutDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/Modules/%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeAppHostFile)"
           DestinationFiles="@(_PowerShellSDKRuntimeNativeAppHostFile->'$(OutDir)%(RelativeDirectory)/%(Filename)%(Extension)')"
@@ -601,6 +591,22 @@
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
         <PowerShellSDKRuntimeNativeSharedPayload>true</PowerShellSDKRuntimeNativeSharedPayload>
       </ResolvedFileToPublish>
+      <ResolvedFileToPublish Include="@(_PowerShellSDKRuntimeNativeSharedRuntimeFile)">
+        <RelativePath>runtimes\$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)\lib\$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)\%(_PowerShellSDKRuntimeNativeSharedRuntimeFile.Filename)%(_PowerShellSDKRuntimeNativeSharedRuntimeFile.Extension)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <PowerShellSDKRuntimeNativeSharedPayload>true</PowerShellSDKRuntimeNativeSharedPayload>
+      </ResolvedFileToPublish>
+      <ResolvedFileToPublish Include="@(_PowerShellSDKRuntimeNativeSharedCompanionFile)"
+                             Condition="'@(_PowerShellSDKRuntimeNativeSharedCompanionFile)' != ''">
+        <RelativePath>runtimes\$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)\lib\$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)\%(_PowerShellSDKRuntimeNativeSharedCompanionFile.Filename)%(_PowerShellSDKRuntimeNativeSharedCompanionFile.Extension)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <PowerShellSDKRuntimeNativeSharedPayload>true</PowerShellSDKRuntimeNativeSharedPayload>
+      </ResolvedFileToPublish>
+      <ResolvedFileToPublish Include="@(_PowerShellSDKRuntimeNativeSharedModuleFile)">
+        <RelativePath>runtimes\$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)\lib\$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)\Modules\%(_PowerShellSDKRuntimeNativeSharedModuleFile.RecursiveDir)%(_PowerShellSDKRuntimeNativeSharedModuleFile.Filename)%(_PowerShellSDKRuntimeNativeSharedModuleFile.Extension)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <PowerShellSDKRuntimeNativeSharedPayload>true</PowerShellSDKRuntimeNativeSharedPayload>
+      </ResolvedFileToPublish>
       <ResolvedFileToPublish Include="@(_PowerShellSDKRuntimeNativeAppHostFile)">
         <RelativePath>%(_PowerShellSDKRuntimeNativeAppHostFile.RelativeDirectory)\%(_PowerShellSDKRuntimeNativeAppHostFile.Filename)%(_PowerShellSDKRuntimeNativeAppHostFile.Extension)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
@@ -668,15 +674,10 @@
           AfterTargets="Publish"
           Condition="'$(_PowerShellSDKRuntimeNativeCopyToPublishEnabled)' == 'true'">
     <ItemGroup>
-      <_PowerShellSDKAutomaticSharedPublishPayloadFile Include="$(PublishDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/*.dll;$(PublishDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/*.xml;$(PublishDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/*.config" />
       <_PowerShellSDKRuntimeNativeSharedPublishDependencySourceFile Include="$(PublishDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadRid)/lib/**/*.dll" />
       <_PowerShellSDKRuntimeNativeSharedPublishDependencyFile Include="@(_PowerShellSDKRuntimeNativeSharedPublishDependencySourceFile)"
                                                               Condition="!Exists('$(PublishDir)%(_PowerShellSDKRuntimeNativeSharedPublishDependencySourceFile.Filename)%(_PowerShellSDKRuntimeNativeSharedPublishDependencySourceFile.Extension)')" />
     </ItemGroup>
-    <Delete Files="@(_PowerShellSDKAutomaticSharedPublishPayloadFile)"
-            Condition="'@(_PowerShellSDKAutomaticSharedPublishPayloadFile)' != ''" />
-    <RemoveDir Directories="$(PublishDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/Modules"
-               Condition="Exists('$(PublishDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/Modules')" />
     <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeSharedPublishDependencyFile)"
           DestinationFolder="$(PublishDir)"
           SkipUnchangedFiles="true"

--- a/eng/Validate-PowerShellSdkPackage.ps1
+++ b/eng/Validate-PowerShellSdkPackage.ps1
@@ -200,7 +200,7 @@ function Assert-AppHostOutput {
     [string] $Description
   )
 
-  foreach ($FileName in @($ExecutableName, 'pwsh.dll', 'pwsh.runtimeconfig.json', 'Microsoft.PowerShell.ConsoleHost.dll', 'System.Management.Automation.dll')) {
+  foreach ($FileName in @($ExecutableName, 'pwsh.dll', 'pwsh.runtimeconfig.json')) {
     $OutputPath = Join-Path $Directory $FileName
     if (-not (Test-Path $OutputPath -PathType Leaf)) {
       throw "$Description is missing expected apphost file: $OutputPath"
@@ -334,8 +334,34 @@ function Get-SourceBuiltRuntimePackageAsset {
   )
 }
 
-function Assert-NoSharedPowerShellRuntimeLibDuplicate {
+function Get-SourceBuiltRuntimePackagePayload {
   param(
+    [Parameter(Mandatory)]
+    [string[]] $SourceBuiltPackageAssetEntries,
+
+    [Parameter(Mandatory)]
+    [string] $RuntimeAssetGroup,
+
+    [Parameter(Mandatory)]
+    [string] $TargetFramework
+  )
+
+  $RuntimeAssetPrefix = "runtimes/$RuntimeAssetGroup/lib/$TargetFramework/"
+  return @(
+    $SourceBuiltPackageAssetEntries |
+      Where-Object {
+        $_.StartsWith($RuntimeAssetPrefix, [System.StringComparison]::OrdinalIgnoreCase) -and
+        $_.EndsWith('.dll', [System.StringComparison]::OrdinalIgnoreCase)
+      } |
+      Sort-Object -Unique
+  )
+}
+
+function Assert-SharedPowerShellRuntimeLibPreserved {
+  param(
+    [Parameter(Mandatory)]
+    [string] $RestoredSdkPath,
+
     [Parameter(Mandatory)]
     [string] $Directory,
 
@@ -352,16 +378,20 @@ function Assert-NoSharedPowerShellRuntimeLibDuplicate {
     [string] $Description
   )
 
-  foreach ($RelativePayloadPath in Get-SourceBuiltRuntimePackageAsset -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework) {
-    $PayloadPath = Join-Path $Directory ($RelativePayloadPath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
-    if (Test-Path $PayloadPath) {
-      throw "$Description unexpectedly duplicated shared PowerShell payload under runtime lib asset directory: $PayloadPath"
-    }
+  foreach ($RelativePayloadPath in Get-SourceBuiltRuntimePackagePayload -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework) {
+    $ExpectedPath = Join-Path $RestoredSdkPath ($RelativePayloadPath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+    $ActualPath = Join-Path $Directory ($RelativePayloadPath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+    Assert-FileContentMatches -ExpectedPath $ExpectedPath -ActualPath $ActualPath -Description "$Description runtime lib $RelativePayloadPath"
   }
 
-  $ModulePayloadPath = Join-Path $Directory ("runtimes/$RuntimeAssetGroup/lib/$TargetFramework/Modules/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1" -replace '/', [System.IO.Path]::DirectorySeparatorChar)
-  if (Test-Path $ModulePayloadPath) {
-    throw "$Description unexpectedly duplicated shared PowerShell module payload under runtime lib asset directory: $ModulePayloadPath"
+  foreach ($RelativeModulePath in @(
+      "runtimes/$RuntimeAssetGroup/lib/$TargetFramework/Modules/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1",
+      "runtimes/$RuntimeAssetGroup/lib/$TargetFramework/Modules/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1",
+      "runtimes/$RuntimeAssetGroup/lib/$TargetFramework/Modules/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.psd1")) {
+    $ModulePayloadPath = Join-Path $Directory ($RelativeModulePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+    if (-not (Test-Path $ModulePayloadPath -PathType Leaf)) {
+      throw "$Description is missing shared PowerShell module payload under runtime lib asset directory: $ModulePayloadPath"
+    }
   }
 }
 
@@ -469,6 +499,68 @@ function Assert-FileContentMatches {
   $ActualHash = (Get-FileHash -LiteralPath $ActualPath -Algorithm SHA256).Hash
   if ($ActualHash -ne $ExpectedHash) {
     throw "$Description file content mismatch. Expected '$ExpectedPath' ($ExpectedHash), got '$ActualPath' ($ActualHash)."
+  }
+}
+
+function Assert-OutputContainsPath {
+  param(
+    [Parameter(Mandatory)]
+    [object[]] $Output,
+
+    [Parameter(Mandatory)]
+    [string] $ExpectedPath,
+
+    [Parameter(Mandatory)]
+    [string] $Description
+  )
+
+  $ResolvedExpectedPath = (Resolve-Path -LiteralPath $ExpectedPath).Path.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+  foreach ($Line in @($Output)) {
+    $NormalizedLine = ([string] $Line).Trim().TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+    if ([System.String]::Equals($NormalizedLine, $ResolvedExpectedPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+      return
+    }
+  }
+
+  throw "$Description output did not contain expected path '$ResolvedExpectedPath'. Output: $($Output -join [Environment]::NewLine)"
+}
+
+function Assert-AppDepsRuntimeTargetsPreserved {
+  param(
+    [Parameter(Mandatory)]
+    [string] $Directory,
+
+    [Parameter(Mandatory)]
+    [string] $AssemblyName,
+
+    [Parameter(Mandatory)]
+    [string] $RuntimeAssetGroup,
+
+    [Parameter(Mandatory)]
+    [string] $TargetFramework,
+
+    [Parameter(Mandatory)]
+    [string] $Description
+  )
+
+  $DepsPath = Join-Path $Directory "$AssemblyName.deps.json"
+  if (-not (Test-Path $DepsPath -PathType Leaf)) {
+    throw "$Description is missing application deps file: $DepsPath"
+  }
+
+  $DepsText = Get-Content -LiteralPath $DepsPath -Raw
+  foreach ($RelativeRuntimePath in @(
+      "runtimes/$RuntimeAssetGroup/lib/$TargetFramework/System.Management.Automation.dll",
+      "runtimes/$RuntimeAssetGroup/lib/$TargetFramework/Microsoft.PowerShell.Security.dll",
+      "runtimes/$RuntimeAssetGroup/lib/$TargetFramework/Microsoft.PowerShell.Commands.Management.dll")) {
+    if ($DepsText -notmatch [regex]::Escape($RelativeRuntimePath)) {
+      throw "$Description deps file does not reference expected runtime target '$RelativeRuntimePath': $DepsPath"
+    }
+
+    $PhysicalPath = Join-Path $Directory ($RelativeRuntimePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+    if (-not (Test-Path $PhysicalPath -PathType Leaf)) {
+      throw "$Description deps file references '$RelativeRuntimePath', but the copied file is missing: $PhysicalPath"
+    }
   }
 }
 
@@ -635,6 +727,371 @@ function Invoke-RuntimeNativeOverwriteProbe {
   }
 }
 
+function Invoke-RuntimeNativeNoRuntimeIdentifierInProcessProbe {
+  param(
+    [Parameter(Mandatory)]
+    [string] $ValidationRoot,
+
+    [Parameter(Mandatory)]
+    [string] $PackageDirectoryPath,
+
+    [Parameter(Mandatory)]
+    [string] $PackageId,
+
+    [Parameter(Mandatory)]
+    [string] $PackageVersion,
+
+    [Parameter(Mandatory)]
+    [string] $SampleTargetFramework,
+
+    [Parameter(Mandatory)]
+    [string] $TargetFramework,
+
+    [Parameter(Mandatory)]
+    [string] $RuntimeAssetGroup,
+
+    [Parameter(Mandatory)]
+    [string[]] $RuntimeNativeValidationRids,
+
+    [Parameter(Mandatory)]
+    [string] $RestoredSdkPath,
+
+    [Parameter(Mandatory)]
+    [string[]] $SourceBuiltPackageAssetEntries,
+
+    [Parameter(Mandatory)]
+    [string[]] $PSGalleryProbeModuleNames
+  )
+
+  $ProbeDirectory = Join-Path $ValidationRoot 'sample-runtime-native-no-rid'
+  New-Item $ProbeDirectory -ItemType Directory -Force | Out-Null
+
+  $PreviousLocation = Get-Location
+  try {
+    Push-Location $ProbeDirectory
+
+    Invoke-DotNet @('new', 'console', '--framework', $TargetFramework, '--no-restore')
+    $ProjectPath = (Get-ChildItem -LiteralPath $ProbeDirectory -Filter '*.csproj' | Select-Object -First 1).FullName
+    if (-not $ProjectPath) {
+      throw "No no-RID RuntimeNative sample project was generated in $ProbeDirectory"
+    }
+
+    $EscapedPackageDirectoryPath = [System.Security.SecurityElement]::Escape($PackageDirectoryPath)
+    $NuGetConfig = @"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="ci-nupkg" value="$EscapedPackageDirectoryPath" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="ci-nupkg">
+      <package pattern="$PackageId" />
+    </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>
+"@
+    Set-Content -Path (Join-Path $ProbeDirectory 'nuget.config') -Value $NuGetConfig -Encoding utf8
+
+    $Program = @'
+using System;
+using System.Management.Automation;
+
+using PowerShell ps = PowerShell.Create();
+ps.AddScript(@"
+$ErrorActionPreference = 'Stop'
+    Import-Module Microsoft.PowerShell.Security -ErrorAction Stop
+    [void] (Get-Command Set-ExecutionPolicy -ErrorAction Stop)
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) {
+        Set-ExecutionPolicy Bypass -Scope Process -ErrorAction Stop
+    }
+    Import-Module Microsoft.PowerShell.Management -ErrorAction Stop
+    [void] (Get-Command Get-Process -ErrorAction Stop)
+    $process = Get-Process | Select-Object -First 1
+    if ($null -eq $process) {
+        throw 'Get-Process returned no process'
+    }
+    $securityModulePath = Join-Path $PSHOME 'Modules/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.psd1'
+    $managementModulePath = Join-Path $PSHOME 'Modules/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1'
+    if (-not (Test-Path -LiteralPath $securityModulePath -PathType Leaf)) {
+        throw ('Microsoft.PowerShell.Security module manifest is not under PSHOME: {0}' -f $securityModulePath)
+    }
+    if (-not (Test-Path -LiteralPath $managementModulePath -PathType Leaf)) {
+        throw ('Microsoft.PowerShell.Management module manifest is not under PSHOME: {0}' -f $managementModulePath)
+    }
+    $PSHOME
+    $securityModulePath
+    $managementModulePath
+    ");
+
+foreach (PSObject result in ps.Invoke())
+{
+    Console.WriteLine(result);
+}
+
+foreach (ErrorRecord error in ps.Streams.Error)
+{
+    Console.Error.WriteLine(error.ToString());
+}
+
+if (ps.HadErrors)
+{
+    Environment.Exit(2);
+}
+'@
+    Set-Content -Path (Join-Path $ProbeDirectory 'Program.cs') -Value $Program -Encoding utf8
+
+    [xml] $Project = Get-Content -LiteralPath $ProjectPath
+    $PropertyGroup = @($Project.Project.PropertyGroup)[0]
+    $TargetFrameworkElement = $PropertyGroup.SelectSingleNode('TargetFramework')
+    if ($TargetFrameworkElement) {
+      $TargetFrameworkElement.InnerText = $SampleTargetFramework
+    } else {
+      Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'TargetFramework' -Value $SampleTargetFramework
+    }
+    Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'PowerShellSDKAppHostLayout' -Value 'RuntimeNative'
+    Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'PowerShellSDKAppHostImplementation' -Value 'MultiPwsh'
+    Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers' -Value ($RuntimeNativeValidationRids -join ';')
+    Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'PowerShellSDKPSGalleryModules' -Value 'All'
+    $Project.Save($ProjectPath)
+
+    Invoke-DotNet @('add', $ProjectPath, 'package', $PackageId, '--version', $PackageVersion, '--no-restore')
+    Invoke-DotNet @('restore', $ProjectPath, '--configfile', (Join-Path $ProbeDirectory 'nuget.config'), '--verbosity', 'minimal')
+    Invoke-DotNet @('build', $ProjectPath, '--no-restore', '--nologo', '--verbosity', 'minimal')
+
+    $ProbeOutputDirectory = Join-Path $ProbeDirectory (Join-Path 'bin' (Join-Path 'Debug' $SampleTargetFramework))
+    Assert-SharedPowerShellOutput -Directory $ProbeOutputDirectory -SelfContained $false -Description 'No-RID RuntimeNative sample output'
+    Assert-PowerShellConfig -Directory $ProbeOutputDirectory -ExpectedExecutionPolicy 'Bypass' -Description 'No-RID RuntimeNative sample output'
+    Assert-SharedPowerShellRuntimeLibPreserved -RestoredSdkPath $RestoredSdkPath -Directory $ProbeOutputDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'No-RID RuntimeNative sample output'
+    Assert-SourceBuiltPackagePayloadPreserved -RestoredSdkPath $RestoredSdkPath -Directory $ProbeOutputDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'No-RID RuntimeNative sample output'
+    Assert-PSGalleryModulesPresent -Directory $ProbeOutputDirectory -ModuleNames $PSGalleryProbeModuleNames -Description 'No-RID RuntimeNative sample output'
+    foreach ($RuntimeNativeRid in $RuntimeNativeValidationRids) {
+      $RuntimeNativeExecutableName = if ($RuntimeNativeRid -like 'win-*') { 'pwsh.exe' } else { 'pwsh' }
+      Assert-NoRootRuntimeNativeAppHostOutput -Directory $ProbeOutputDirectory -ExecutableName $RuntimeNativeExecutableName -Description "No-RID RuntimeNative sample output [$RuntimeNativeRid]"
+      [void] (Assert-RuntimeNativeAppHostOutput -Directory $ProbeOutputDirectory -RuntimeIdentifier $RuntimeNativeRid -ExecutableName $RuntimeNativeExecutableName -SelfContained $false -Description "No-RID RuntimeNative sample output [$RuntimeNativeRid]")
+    }
+
+    $ProbeOutput = & dotnet run --project $ProjectPath --no-build
+    if ($LASTEXITCODE -ne 0) {
+      throw "No-RID RuntimeNative sample failed with exit code $LASTEXITCODE"
+    }
+
+    $ExpectedPSHome = Join-Path $ProbeOutputDirectory "runtimes/$RuntimeAssetGroup/lib/$TargetFramework"
+    Assert-OutputContainsPath -Output $ProbeOutput -ExpectedPath $ExpectedPSHome -Description 'No-RID RuntimeNative sample'
+    Assert-OutputContainsPath -Output $ProbeOutput -ExpectedPath (Join-Path $ExpectedPSHome 'Modules/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.psd1') -Description 'No-RID RuntimeNative sample'
+    Assert-OutputContainsPath -Output $ProbeOutput -ExpectedPath (Join-Path $ExpectedPSHome 'Modules/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1') -Description 'No-RID RuntimeNative sample'
+  } finally {
+    Set-Location $PreviousLocation
+  }
+}
+
+function Invoke-AppHostLayoutMatrixProbe {
+  param(
+    [Parameter(Mandatory)]
+    [string] $ValidationRoot,
+
+    [Parameter(Mandatory)]
+    [string] $PackageDirectoryPath,
+
+    [Parameter(Mandatory)]
+    [string] $PackageId,
+
+    [Parameter(Mandatory)]
+    [string] $PackageVersion,
+
+    [Parameter(Mandatory)]
+    [string] $SampleTargetFramework,
+
+    [Parameter(Mandatory)]
+    [string] $TargetFramework,
+
+    [Parameter(Mandatory)]
+    [string] $RuntimeAssetGroup,
+
+    [Parameter(Mandatory)]
+    [string] $CurrentRuntimeIdentifier,
+
+    [Parameter(Mandatory)]
+    [string[]] $RuntimeNativeValidationRids,
+
+    [Parameter(Mandatory)]
+    [string] $ExecutableName,
+
+    [Parameter(Mandatory)]
+    [string] $PowerShellVersion,
+
+    [Parameter(Mandatory)]
+    [string] $RestoredSdkPath,
+
+    [Parameter(Mandatory)]
+    [string[]] $SourceBuiltPackageAssetEntries,
+
+    [Parameter(Mandatory)]
+    [string[]] $PSGalleryProbeModuleNames
+  )
+
+  $Layouts = @(
+    [pscustomobject]@{ Name = 'None'; AppHostLayout = ''; ExpectRootAppHost = $false; ExpectRuntimeNativeAppHost = $false; CopyPSGalleryModules = $false },
+    [pscustomobject]@{ Name = 'Root'; AppHostLayout = 'Root'; ExpectRootAppHost = $true; ExpectRuntimeNativeAppHost = $false; CopyPSGalleryModules = $false },
+    [pscustomobject]@{ Name = 'RuntimeNative'; AppHostLayout = 'RuntimeNative'; ExpectRootAppHost = $false; ExpectRuntimeNativeAppHost = $true; CopyPSGalleryModules = $true },
+    [pscustomobject]@{ Name = 'Both'; AppHostLayout = 'Both'; ExpectRootAppHost = $true; ExpectRuntimeNativeAppHost = $true; CopyPSGalleryModules = $true }
+  )
+
+  foreach ($Layout in $Layouts) {
+    $ProbeDirectory = Join-Path $ValidationRoot "sample-layout-$($Layout.Name.ToLowerInvariant())"
+    New-Item $ProbeDirectory -ItemType Directory -Force | Out-Null
+
+    $PreviousLocation = Get-Location
+    try {
+      Push-Location $ProbeDirectory
+
+      Invoke-DotNet @('new', 'console', '--framework', $TargetFramework, '--no-restore')
+      $ProjectPath = (Get-ChildItem -LiteralPath $ProbeDirectory -Filter '*.csproj' | Select-Object -First 1).FullName
+      if (-not $ProjectPath) {
+        throw "No $($Layout.Name) layout sample project was generated in $ProbeDirectory"
+      }
+
+      $EscapedPackageDirectoryPath = [System.Security.SecurityElement]::Escape($PackageDirectoryPath)
+      $NuGetConfig = @"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="ci-nupkg" value="$EscapedPackageDirectoryPath" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="ci-nupkg">
+      <package pattern="$PackageId" />
+    </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>
+"@
+      Set-Content -Path (Join-Path $ProbeDirectory 'nuget.config') -Value $NuGetConfig -Encoding utf8
+
+      $Program = @'
+using System;
+using System.Management.Automation;
+
+using PowerShell ps = PowerShell.Create();
+ps.AddScript(@"
+$ErrorActionPreference = 'Stop'
+$env:PSModulePath = ''
+[void] (Get-Command Set-ExecutionPolicy -ErrorAction Stop)
+if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) {
+    Set-ExecutionPolicy Bypass -Scope Process -ErrorAction Stop
+}
+[void] (Get-Command Get-Process -ErrorAction Stop)
+$process = Get-Process | Select-Object -First 1
+if ($null -eq $process) {
+    throw 'Get-Process returned no process'
+}
+$securityModulePath = Join-Path $PSHOME 'Modules/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.psd1'
+$managementModulePath = Join-Path $PSHOME 'Modules/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1'
+if (-not (Test-Path -LiteralPath $securityModulePath -PathType Leaf)) {
+    throw ('Microsoft.PowerShell.Security module manifest is not under PSHOME: {0}' -f $securityModulePath)
+}
+if (-not (Test-Path -LiteralPath $managementModulePath -PathType Leaf)) {
+    throw ('Microsoft.PowerShell.Management module manifest is not under PSHOME: {0}' -f $managementModulePath)
+}
+$PSHOME
+$securityModulePath
+$managementModulePath
+");
+
+foreach (PSObject result in ps.Invoke())
+{
+    Console.WriteLine(result);
+}
+
+foreach (ErrorRecord error in ps.Streams.Error)
+{
+    Console.Error.WriteLine(error.ToString());
+}
+
+if (ps.HadErrors)
+{
+    Environment.Exit(2);
+}
+'@
+      Set-Content -Path (Join-Path $ProbeDirectory 'Program.cs') -Value $Program -Encoding utf8
+
+      [xml] $Project = Get-Content -LiteralPath $ProjectPath
+      $PropertyGroup = @($Project.Project.PropertyGroup)[0]
+      $TargetFrameworkElement = $PropertyGroup.SelectSingleNode('TargetFramework')
+      if ($TargetFrameworkElement) {
+        $TargetFrameworkElement.InnerText = $SampleTargetFramework
+      } else {
+        Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'TargetFramework' -Value $SampleTargetFramework
+      }
+      if ($Layout.AppHostLayout) {
+        Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'PowerShellSDKAppHostLayout' -Value $Layout.AppHostLayout
+        Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'PowerShellSDKAppHostImplementation' -Value 'MultiPwsh'
+      }
+      if ($Layout.ExpectRuntimeNativeAppHost) {
+        Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'PowerShellSDKRuntimeNativeAppHostRuntimeIdentifiers' -Value ($RuntimeNativeValidationRids -join ';')
+      }
+      if ($Layout.CopyPSGalleryModules) {
+        Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'PowerShellSDKPSGalleryModules' -Value 'All'
+      }
+      $Project.Save($ProjectPath)
+
+      Invoke-DotNet @('add', $ProjectPath, 'package', $PackageId, '--version', $PackageVersion, '--no-restore')
+      Invoke-DotNet @('restore', $ProjectPath, '--configfile', (Join-Path $ProbeDirectory 'nuget.config'), '--verbosity', 'minimal')
+      Invoke-DotNet @('build', $ProjectPath, '--no-restore', '--nologo', '--verbosity', 'minimal')
+
+      $AssemblyName = Split-Path $ProjectPath -LeafBase
+      $ProbeOutputDirectory = Join-Path $ProbeDirectory (Join-Path 'bin' (Join-Path 'Debug' $SampleTargetFramework))
+      $Description = "$($Layout.Name) layout sample output"
+      $ExpectedPSHome = Join-Path $ProbeOutputDirectory "runtimes/$RuntimeAssetGroup/lib/$TargetFramework"
+
+      Assert-SharedPowerShellRuntimeLibPreserved -RestoredSdkPath $RestoredSdkPath -Directory $ProbeOutputDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description $Description
+      Assert-AppDepsRuntimeTargetsPreserved -Directory $ProbeOutputDirectory -AssemblyName $AssemblyName -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description $Description
+
+      if ($Layout.AppHostLayout) {
+        Assert-PowerShellConfig -Directory $ProbeOutputDirectory -ExpectedExecutionPolicy 'Bypass' -Description $Description
+      }
+      if ($Layout.CopyPSGalleryModules) {
+        Assert-PSGalleryModulesPresent -Directory $ProbeOutputDirectory -ModuleNames $PSGalleryProbeModuleNames -Description $Description
+      }
+      if ($Layout.ExpectRootAppHost) {
+        Assert-AppHostOutput -Directory $ProbeOutputDirectory -ExecutableName $ExecutableName -Description $Description
+        $RootPwshPath = Join-Path $ProbeOutputDirectory $ExecutableName
+        [void] (Invoke-PwshVersionCheck -PwshPath $RootPwshPath -ExpectedVersion $PowerShellVersion)
+        Invoke-PwshModuleProbe -PwshPath $RootPwshPath -ModuleRoot (Join-Path $ProbeOutputDirectory 'Modules')
+      }
+      if ($Layout.ExpectRuntimeNativeAppHost) {
+        foreach ($RuntimeNativeRid in $RuntimeNativeValidationRids) {
+          $RuntimeNativeExecutableName = if ($RuntimeNativeRid -like 'win-*') { 'pwsh.exe' } else { 'pwsh' }
+          $RuntimeNativePwshPath = Assert-RuntimeNativeAppHostOutput -Directory $ProbeOutputDirectory -RuntimeIdentifier $RuntimeNativeRid -ExecutableName $RuntimeNativeExecutableName -SelfContained $false -Description "$Description [$RuntimeNativeRid]"
+          if ($RuntimeNativeRid -eq $CurrentRuntimeIdentifier) {
+            [void] (Invoke-PwshVersionCheck -PwshPath $RuntimeNativePwshPath -ExpectedVersion $PowerShellVersion)
+            Invoke-PwshModuleProbe -PwshPath $RuntimeNativePwshPath -ModuleRoot (Join-Path $ProbeOutputDirectory 'Modules')
+          }
+        }
+      }
+
+      $ProbeOutput = & dotnet run --project $ProjectPath --no-build
+      if ($LASTEXITCODE -ne 0) {
+        throw "$($Layout.Name) layout sample failed with exit code $LASTEXITCODE"
+      }
+
+      Assert-OutputContainsPath -Output $ProbeOutput -ExpectedPath $ExpectedPSHome -Description "$($Layout.Name) layout sample"
+      Assert-OutputContainsPath -Output $ProbeOutput -ExpectedPath (Join-Path $ExpectedPSHome 'Modules/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.psd1') -Description "$($Layout.Name) layout sample"
+      Assert-OutputContainsPath -Output $ProbeOutput -ExpectedPath (Join-Path $ExpectedPSHome 'Modules/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1') -Description "$($Layout.Name) layout sample"
+    } finally {
+      Set-Location $PreviousLocation
+    }
+  }
+}
+
 function Assert-RuntimeConfigMode {
   param(
     [Parameter(Mandatory)]
@@ -704,7 +1161,7 @@ function Invoke-PwshModuleProbe {
     $ModuleProbe = @'
 $ErrorActionPreference = 'Stop'
 $expectedModuleRoot = $env:PowerShellSDKExpectedModuleRoot
-foreach ($moduleName in 'Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Utility') {
+foreach ($moduleName in 'Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Utility', 'Microsoft.PowerShell.Security') {
   $module = $null
   foreach ($candidate in Get-Module -ListAvailable $moduleName) {
     $module = $candidate
@@ -727,6 +1184,11 @@ if ($getProcess.Source -ne 'Microsoft.PowerShell.Management') {
 $selectObject = Get-Command Select-Object -ErrorAction Stop
 if ($selectObject.Source -ne 'Microsoft.PowerShell.Utility') {
   throw "Select-Object resolved from '$($selectObject.Source)' instead of Microsoft.PowerShell.Utility"
+}
+
+$setExecutionPolicy = Get-Command Set-ExecutionPolicy -ErrorAction Stop
+if ($setExecutionPolicy.Source -ne 'Microsoft.PowerShell.Security') {
+  throw "Set-ExecutionPolicy resolved from '$($setExecutionPolicy.Source)' instead of Microsoft.PowerShell.Security"
 }
 '@
     $PwshModuleProbeOutput = & $PwshPath -NoLogo -NoProfile -NonInteractive -Command $ModuleProbe
@@ -1204,7 +1666,7 @@ foreach (PSObject result in ps.Invoke())
   Assert-SharedPowerShellOutput -Directory $OutputDirectory -SelfContained $false -Description 'Sample app output'
   Assert-PowerShellConfig -Directory $OutputDirectory -ExpectedExecutionPolicy 'Bypass' -Description 'Sample app output'
   Assert-NoRootRuntimeNativeAppHostOutput -Directory $OutputDirectory -ExecutableName $ExecutableName -Description 'Sample app output'
-  Assert-NoSharedPowerShellRuntimeLibDuplicate -Directory $OutputDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'Sample app output'
+  Assert-SharedPowerShellRuntimeLibPreserved -RestoredSdkPath $RestoredSdkPath -Directory $OutputDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'Sample app output'
   Assert-PSGalleryModulesAbsent -Directory $OutputDirectory -ModuleNames $PSGalleryModulePackageIds -Description 'Sample app output'
   Assert-SourceBuiltPackagePayloadPreserved -RestoredSdkPath $RestoredSdkPath -Directory $OutputDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'Sample app output'
   foreach ($RuntimeNativeRid in $RuntimeNativeValidationRids) {
@@ -1272,13 +1734,15 @@ foreach (PSObject result in ps.Invoke())
     throw "Sample app imported PowerShell SDK version '$AppVersion', expected '$PowerShellVersion'"
   }
 
+  Invoke-AppHostLayoutMatrixProbe -ValidationRoot $ValidationRoot -PackageDirectoryPath $PackageDirectoryPath -PackageId $PackageId -PackageVersion $PackageVersion -SampleTargetFramework $SampleTargetFramework -TargetFramework $TargetFramework -RuntimeAssetGroup $RuntimeAssetGroup -CurrentRuntimeIdentifier $RuntimeIdentifier -RuntimeNativeValidationRids $RuntimeNativeValidationRids -ExecutableName $ExecutableName -PowerShellVersion $PowerShellVersion -RestoredSdkPath $RestoredSdkPath -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -PSGalleryProbeModuleNames $PSGalleryProbeModuleNames
+
   Invoke-DotNet @('publish', $ProjectPath, '--nologo', '--verbosity', 'minimal', '-c', 'Release', '-r', $RuntimeIdentifier, '--self-contained', 'true')
 
   $PublishDirectory = Join-Path $SampleDirectory (Join-Path 'bin' (Join-Path 'Release' (Join-Path $SampleTargetFramework (Join-Path $RuntimeIdentifier 'publish'))))
   Assert-SharedPowerShellOutput -Directory $PublishDirectory -SelfContained $true -Description 'Sample self-contained publish output'
   Assert-PowerShellConfig -Directory $PublishDirectory -ExpectedExecutionPolicy 'Bypass' -Description 'Sample self-contained publish output'
   Assert-NoRootRuntimeNativeAppHostOutput -Directory $PublishDirectory -ExecutableName $ExecutableName -Description 'Sample self-contained publish output'
-  Assert-NoSharedPowerShellRuntimeLibDuplicate -Directory $PublishDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'Sample self-contained publish output'
+  Assert-SharedPowerShellRuntimeLibPreserved -RestoredSdkPath $RestoredSdkPath -Directory $PublishDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'Sample self-contained publish output'
   Assert-PSGalleryModulesAbsent -Directory $PublishDirectory -ModuleNames $PSGalleryModulePackageIds -Description 'Sample self-contained publish output'
   Assert-SourceBuiltPackagePayloadPreserved -RestoredSdkPath $RestoredSdkPath -Directory $PublishDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'Sample self-contained publish output'
   foreach ($RuntimeNativeRid in $RuntimeNativeValidationRids) {
@@ -1297,7 +1761,7 @@ foreach (PSObject result in ps.Invoke())
   Assert-SharedPowerShellOutput -Directory $FrameworkDependentPublishDirectory -SelfContained $false -Description 'Sample framework-dependent publish output'
   Assert-PowerShellConfig -Directory $FrameworkDependentPublishDirectory -ExpectedExecutionPolicy 'Bypass' -Description 'Sample framework-dependent publish output'
   Assert-NoRootRuntimeNativeAppHostOutput -Directory $FrameworkDependentPublishDirectory -ExecutableName $ExecutableName -Description 'Sample framework-dependent publish output'
-  Assert-NoSharedPowerShellRuntimeLibDuplicate -Directory $FrameworkDependentPublishDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'Sample framework-dependent publish output'
+  Assert-SharedPowerShellRuntimeLibPreserved -RestoredSdkPath $RestoredSdkPath -Directory $FrameworkDependentPublishDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'Sample framework-dependent publish output'
   Assert-PSGalleryModulesAbsent -Directory $FrameworkDependentPublishDirectory -ModuleNames $PSGalleryModulePackageIds -Description 'Sample framework-dependent publish output'
   Assert-SourceBuiltPackagePayloadPreserved -RestoredSdkPath $RestoredSdkPath -Directory $FrameworkDependentPublishDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'Sample framework-dependent publish output'
   foreach ($RuntimeNativeRid in $RuntimeNativeValidationRids) {
@@ -1355,7 +1819,7 @@ foreach (PSObject result in ps.Invoke())
   Assert-SharedPowerShellOutput -Directory $PSGalleryPublishDirectory -SelfContained $false -Description 'Sample PSGallery publish output'
   Assert-PowerShellConfig -Directory $PSGalleryPublishDirectory -ExpectedExecutionPolicy 'Bypass' -Description 'Sample PSGallery publish output'
   Assert-NoRootRuntimeNativeAppHostOutput -Directory $PSGalleryPublishDirectory -ExecutableName $ExecutableName -Description 'Sample PSGallery publish output'
-  Assert-NoSharedPowerShellRuntimeLibDuplicate -Directory $PSGalleryPublishDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'Sample PSGallery publish output'
+  Assert-SharedPowerShellRuntimeLibPreserved -RestoredSdkPath $RestoredSdkPath -Directory $PSGalleryPublishDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'Sample PSGallery publish output'
   Assert-PSGalleryModulesPresent -Directory $PSGalleryPublishDirectory -ModuleNames $PSGallerySubsetModuleNames -Description 'Sample PSGallery publish output'
   Assert-PSGalleryModulesAbsent -Directory $PSGalleryPublishDirectory -ModuleNames $UnexpectedPSGallerySubsetModuleNames -Description 'Sample PSGallery publish output'
   $PSGalleryPublishRuntimeNativePwshPath = Assert-RuntimeNativeAppHostOutput -Directory $PSGalleryPublishDirectory -RuntimeIdentifier $RuntimeIdentifier -ExecutableName $ExecutableName -SelfContained $false -Description "Sample PSGallery publish output [$RuntimeIdentifier]"


### PR DESCRIPTION
## Summary
- Preserve `runtimes/<rid-or-group>/lib/<tfm>` payloads so consuming apps' `.deps.json` files still agree with physical files for in-process `PowerShell.Create()`.
- Keep root and runtime-native `pwsh` apphosts usable across `Root`, `RuntimeNative`, and `Both` layouts.
- Extend SDK package validation to cover `None`, `Root`, `RuntimeNative`, and `Both`, including no-RID RDM-shaped in-process hosting, `$PSHOME`, `Set-ExecutionPolicy`, `Get-Process`, Security/Management autoload, deps/runtime-file agreement, and external apphost probes.
- Document the apphost target framework override and RuntimeNative runtime/lib preservation behavior.

## Validation
- Parsed `eng\Microsoft.PowerShell.SDK.targets` as XML.
- Parsed `eng\Validate-PowerShellSdkPackage.ps1` with the PowerShell parser.
- Ran `git diff --check`.
- Ran `pwsh .\scripts\Initialize-Repository.ps1` and confirmed `PowerShellTargetFramework=net10.0`.
- Ran full local `win-x64` SDK package validation with `TF_BUILD=True` and `-SkipPinAudit`.

Notes: `-SkipPinAudit` was needed because the bundled pin audit expects the legacy `.github\workflows\powershell.yml` file, which is absent in this checkout. `TF_BUILD=True` was needed to avoid upstream PowerShell bootstrap trying to downgrade an already-installed newer global `dotnet-format` tool.

## RDM follow-up
RDM can keep `PowerShellSDKAppHostLayout=RuntimeNative`. Once this fix is published in the next `Devolutions.PowerShell.SDK 7.6.3.x` package, RDM should bump from `7.6.3.2` to that package and validate the custom PowerShell VPN path.