### PR TITLE
Add linux-arm SDK package wiring

### DIFF
--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -316,6 +316,10 @@ jobs:
             runner: ubuntu-24.04
             psbuild-runtime: fxdependent-linux-x64
             executable: pwsh
+          - rid: linux-arm
+            runner: ubuntu-24.04
+            psbuild-runtime: fxdependent-linux-arm
+            executable: pwsh
           - rid: linux-arm64
             runner: ubuntu-24.04-arm
             psbuild-runtime: fxdependent-linux-arm64
@@ -451,6 +455,7 @@ jobs:
             'win-x64' = 'pwsh.exe';
             'win-arm64' = 'pwsh.exe';
             'linux-x64' = 'pwsh';
+            'linux-arm' = 'pwsh';
             'linux-arm64' = 'pwsh';
             'osx-x64' = 'pwsh';
             'osx-arm64' = 'pwsh';
@@ -1128,6 +1133,7 @@ jobs:
             'win-x64' = @('pwsh.exe', 'pwsh.dll', 'pwsh.runtimeconfig.json')
             'win-arm64' = @('pwsh.exe', 'pwsh.dll', 'pwsh.runtimeconfig.json')
             'linux-x64' = @('pwsh', 'pwsh.dll', 'pwsh.runtimeconfig.json')
+            'linux-arm' = @('pwsh', 'pwsh.dll', 'pwsh.runtimeconfig.json')
             'linux-arm64' = @('pwsh', 'pwsh.dll', 'pwsh.runtimeconfig.json')
             'osx-x64' = @('pwsh', 'pwsh.dll', 'pwsh.runtimeconfig.json')
             'osx-arm64' = @('pwsh', 'pwsh.dll', 'pwsh.runtimeconfig.json')
@@ -1310,12 +1316,14 @@ jobs:
             'runtimes/win-x64/native',
             'runtimes/win-arm64/native',
             'runtimes/linux-x64/native',
+            'runtimes/linux-arm/native',
             'runtimes/linux-arm64/native',
             'runtimes/osx-x64/native',
             'runtimes/osx-arm64/native',
             'tools/apphost/win-x64',
             'tools/apphost/win-arm64',
             'tools/apphost/linux-x64',
+            'tools/apphost/linux-arm',
             'tools/apphost/linux-arm64',
             'tools/apphost/osx-x64',
             'tools/apphost/osx-arm64',
@@ -1416,6 +1424,9 @@ jobs:
             runner: windows-2025
           - rid: linux-x64
             runner: ubuntu-24.04
+          - rid: linux-arm
+            runner: ubuntu-24.04
+            skip-runtime-execution: true
           - rid: linux-arm64
             runner: ubuntu-24.04-arm
           - rid: osx-x64
@@ -1462,11 +1473,18 @@ jobs:
             throw "Invalid SDK package version '$SdkPackageVersion', expected X.Y.Z.R."
           }
 
-          ./eng/Validate-PowerShellSdkPackage.ps1 `
-            -PackageDirectory ./sdk-package `
-            -PowerShellVersion $Env:POWERSHELL_VERSION `
-            -PackageVersion $SdkPackageVersion `
-            -TargetFramework $TargetFramework `
-            -RuntimeIdentifier ${{matrix.rid}} `
-            -PackageId $Env:SDK_PACKAGE_ID `
-            -PackageVendorName $Env:SDK_VENDOR_NAME
+          $ValidateArguments = @(
+            '-PackageDirectory', './sdk-package',
+            '-PowerShellVersion', $Env:POWERSHELL_VERSION,
+            '-PackageVersion', $SdkPackageVersion,
+            '-TargetFramework', $TargetFramework,
+            '-RuntimeIdentifier', '${{matrix.rid}}',
+            '-PackageId', $Env:SDK_PACKAGE_ID,
+            '-PackageVendorName', $Env:SDK_VENDOR_NAME
+          )
+          [bool] $SkipRuntimeExecution = $false
+          if ([System.Boolean]::TryParse('${{matrix.skip-runtime-execution}}', [ref] $SkipRuntimeExecution) -and $SkipRuntimeExecution) {
+            $ValidateArguments += '-SkipRuntimeExecution'
+          }
+
+          ./eng/Validate-PowerShellSdkPackage.ps1 @ValidateArguments

--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -116,7 +116,7 @@ env:
   SDK_PACKAGE_ID: "Devolutions.PowerShell.SDK"
   SDK_PACKAGE_REVISION: "0"
   MULTI_PWSH_APPHOST_PACKAGE_ID: "Devolutions.MultiPwsh.Cli"
-  MULTI_PWSH_APPHOST_PACKAGE_VERSION: "0.14.1"
+  MULTI_PWSH_APPHOST_PACKAGE_VERSION: "0.14.2"
   MULTI_PWSH_APPHOST_PACKAGE_SOURCE: "https://api.nuget.org/v3/index.json"
   PSIGN_TOOL_PACKAGE_ID: "Devolutions.Psign.Tool"
 jobs:
@@ -316,6 +316,10 @@ jobs:
             runner: ubuntu-24.04
             psbuild-runtime: fxdependent-linux-x64
             executable: pwsh
+          - rid: linux-arm
+            runner: ubuntu-24.04
+            psbuild-runtime: fxdependent-linux-arm
+            executable: pwsh
           - rid: linux-arm64
             runner: ubuntu-24.04-arm
             psbuild-runtime: fxdependent-linux-arm64
@@ -451,6 +455,7 @@ jobs:
             'win-x64' = 'pwsh.exe';
             'win-arm64' = 'pwsh.exe';
             'linux-x64' = 'pwsh';
+            'linux-arm' = 'pwsh';
             'linux-arm64' = 'pwsh';
             'osx-x64' = 'pwsh';
             'osx-arm64' = 'pwsh';
@@ -1128,6 +1133,7 @@ jobs:
             'win-x64' = @('pwsh.exe', 'pwsh.dll', 'pwsh.runtimeconfig.json')
             'win-arm64' = @('pwsh.exe', 'pwsh.dll', 'pwsh.runtimeconfig.json')
             'linux-x64' = @('pwsh', 'pwsh.dll', 'pwsh.runtimeconfig.json')
+            'linux-arm' = @('pwsh', 'pwsh.dll', 'pwsh.runtimeconfig.json')
             'linux-arm64' = @('pwsh', 'pwsh.dll', 'pwsh.runtimeconfig.json')
             'osx-x64' = @('pwsh', 'pwsh.dll', 'pwsh.runtimeconfig.json')
             'osx-arm64' = @('pwsh', 'pwsh.dll', 'pwsh.runtimeconfig.json')
@@ -1310,12 +1316,14 @@ jobs:
             'runtimes/win-x64/native',
             'runtimes/win-arm64/native',
             'runtimes/linux-x64/native',
+            'runtimes/linux-arm/native',
             'runtimes/linux-arm64/native',
             'runtimes/osx-x64/native',
             'runtimes/osx-arm64/native',
             'tools/apphost/win-x64',
             'tools/apphost/win-arm64',
             'tools/apphost/linux-x64',
+            'tools/apphost/linux-arm',
             'tools/apphost/linux-arm64',
             'tools/apphost/osx-x64',
             'tools/apphost/osx-arm64',
@@ -1416,6 +1424,9 @@ jobs:
             runner: windows-2025
           - rid: linux-x64
             runner: ubuntu-24.04
+          - rid: linux-arm
+            runner: ubuntu-24.04
+            skip-runtime-execution: true
           - rid: linux-arm64
             runner: ubuntu-24.04-arm
           - rid: osx-x64
@@ -1462,11 +1473,18 @@ jobs:
             throw "Invalid SDK package version '$SdkPackageVersion', expected X.Y.Z.R."
           }
 
-          ./eng/Validate-PowerShellSdkPackage.ps1 `
-            -PackageDirectory ./sdk-package `
-            -PowerShellVersion $Env:POWERSHELL_VERSION `
-            -PackageVersion $SdkPackageVersion `
-            -TargetFramework $TargetFramework `
-            -RuntimeIdentifier ${{matrix.rid}} `
-            -PackageId $Env:SDK_PACKAGE_ID `
-            -PackageVendorName $Env:SDK_VENDOR_NAME
+          $ValidateArguments = @(
+            '-PackageDirectory', './sdk-package',
+            '-PowerShellVersion', $Env:POWERSHELL_VERSION,
+            '-PackageVersion', $SdkPackageVersion,
+            '-TargetFramework', $TargetFramework,
+            '-RuntimeIdentifier', '${{matrix.rid}}',
+            '-PackageId', $Env:SDK_PACKAGE_ID,
+            '-PackageVendorName', $Env:SDK_VENDOR_NAME
+          )
+          [bool] $SkipRuntimeExecution = $false
+          if ([System.Boolean]::TryParse('${{matrix.skip-runtime-execution}}', [ref] $SkipRuntimeExecution) -and $SkipRuntimeExecution) {
+            $ValidateArguments += '-SkipRuntimeExecution'
+          }
+
+          ./eng/Validate-PowerShellSdkPackage.ps1 @ValidateArguments

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The local script writes under `output\local-sdk\<rid>\` and produces a single-RI
 | Latest downstream release tag | `v7.6.3.2` |
 | Latest PowerShell CLI release assets | `PowerShell-7.6.3-<os>-<arch>.tar.gz` for Windows, macOS, and Linux on x64 and arm64 |
 | PowerShell SDK package source | `https://api.nuget.org/v3/index.json` |
-| multi-pwsh apphost package | `Devolutions.MultiPwsh.Cli` / `0.14.1` |
+| multi-pwsh apphost package | `Devolutions.MultiPwsh.Cli` / `0.14.2` |
 | multi-pwsh apphost package source | `https://api.nuget.org/v3/index.json` |
 | psign code signing tool | `Devolutions.Psign.Tool` / `latest (un-pinned)` |
 | .NET runtime workflow | `v10.0.5` |
@@ -86,7 +86,7 @@ dotnet publish -c Release -r win-x64 --self-contained true
 .\bin\Release\net10.0\win-x64\publish\pwsh.exe -NoLogo -NoProfile -Command '$PSVersionTable'
 ```
 
-Use `linux-x64`, `linux-arm64`, `osx-x64`, `osx-arm64`, `win-x64`, or `win-arm64` as the runtime identifier. If you only need the SDK assemblies and do not want an apphost copied to the output, leave `PowerShellSDKAppHostLayout` unset.
+Use `linux-x64`, `linux-arm`, `linux-arm64`, `osx-x64`, `osx-arm64`, `win-x64`, or `win-arm64` as the runtime identifier. If you only need the SDK assemblies and do not want an apphost copied to the output, leave `PowerShellSDKAppHostLayout` unset.
 
 ### PowerShell CLI
 
@@ -186,7 +186,7 @@ The vendored SDK keeps upstream PowerShell build/runtime metadata separate from 
 
 The package keeps original assembly identities (`System.Management.Automation.dll`, `Microsoft.PowerShell.Commands.Utility.dll`, and related assemblies) so consumers only need to change the NuGet package reference. Source-built PowerShell assemblies are discovered from the current `pwsh-src` build outputs and embedded directly in `Devolutions.PowerShell.SDK`; the package records the embedded Microsoft package IDs and source-built package asset paths under `buildTransitive`, and validation fails if any of those package IDs appear in the restore graph. External packages that are not built by this repository, including `Microsoft.PowerShell.Native` and `Microsoft.PowerShell.MarkdownRender`, remain normal public NuGet dependencies.
 
-The SDK package also includes apphost files for `win-x64`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-x64`, and `osx-arm64`. These files are inert by default. A consuming project opts in by choosing an apphost layout. The root layout copies `pwsh`/`pwsh.exe`, `pwsh.dll`, `pwsh.runtimeconfig.json`, runtime assemblies, and built-in module manifests to the app root:
+The SDK package also includes apphost files for `win-x64`, `win-arm64`, `linux-x64`, `linux-arm`, `linux-arm64`, `osx-x64`, and `osx-arm64`. These files are inert by default. A consuming project opts in by choosing an apphost layout. The root layout copies `pwsh`/`pwsh.exe`, `pwsh.dll`, `pwsh.runtimeconfig.json`, runtime assemblies, and built-in module manifests to the app root:
 
 ```xml
 <PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ dotnet publish -c Release -r win-x64 --self-contained true
 .\bin\Release\net10.0\win-x64\publish\pwsh.exe -NoLogo -NoProfile -Command '$PSVersionTable'
 ```
 
-Use `linux-x64`, `linux-arm64`, `osx-x64`, `osx-arm64`, `win-x64`, or `win-arm64` as the runtime identifier. If you only need the SDK assemblies and do not want an apphost copied to the output, leave `PowerShellSDKAppHostLayout` unset.
+Use `linux-x64`, `linux-arm`, `linux-arm64`, `osx-x64`, `osx-arm64`, `win-x64`, or `win-arm64` as the runtime identifier. If you only need the SDK assemblies and do not want an apphost copied to the output, leave `PowerShellSDKAppHostLayout` unset.
 
 ### PowerShell CLI
 
@@ -186,7 +186,7 @@ The vendored SDK keeps upstream PowerShell build/runtime metadata separate from 
 
 The package keeps original assembly identities (`System.Management.Automation.dll`, `Microsoft.PowerShell.Commands.Utility.dll`, and related assemblies) so consumers only need to change the NuGet package reference. Source-built PowerShell assemblies are discovered from the current `pwsh-src` build outputs and embedded directly in `Devolutions.PowerShell.SDK`; the package records the embedded Microsoft package IDs and source-built package asset paths under `buildTransitive`, and validation fails if any of those package IDs appear in the restore graph. External packages that are not built by this repository, including `Microsoft.PowerShell.Native` and `Microsoft.PowerShell.MarkdownRender`, remain normal public NuGet dependencies.
 
-The SDK package also includes apphost files for `win-x64`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-x64`, and `osx-arm64`. These files are inert by default. A consuming project opts in by choosing an apphost layout. The root layout copies `pwsh`/`pwsh.exe`, `pwsh.dll`, `pwsh.runtimeconfig.json`, runtime assemblies, and built-in module manifests to the app root:
+The SDK package also includes apphost files for `win-x64`, `win-arm64`, `linux-x64`, `linux-arm`, `linux-arm64`, `osx-x64`, and `osx-arm64`. These files are inert by default. A consuming project opts in by choosing an apphost layout. The root layout copies `pwsh`/`pwsh.exe`, `pwsh.dll`, `pwsh.runtimeconfig.json`, runtime assemblies, and built-in module manifests to the app root:
 
 ```xml
 <PropertyGroup>

--- a/eng/Microsoft.PowerShell.SDK.targets
+++ b/eng/Microsoft.PowerShell.SDK.targets
@@ -270,6 +270,10 @@
         <ExecutableName>pwsh</ExecutableName>
         <RequiresChmod>true</RequiresChmod>
       </_PowerShellSDKRuntimeNativeSupportedRid>
+      <_PowerShellSDKRuntimeNativeSupportedRid Include="linux-arm">
+        <ExecutableName>pwsh</ExecutableName>
+        <RequiresChmod>true</RequiresChmod>
+      </_PowerShellSDKRuntimeNativeSupportedRid>
       <_PowerShellSDKRuntimeNativeSupportedRid Include="linux-arm64">
         <ExecutableName>pwsh</ExecutableName>
         <RequiresChmod>true</RequiresChmod>
@@ -286,7 +290,7 @@
       <_PowerShellSDKRuntimeNativeRequestedRid Include="$([MSBuild]::Unescape('$(_PowerShellSDKRuntimeNativeRequestedRidList)'))"
                                                Condition="'$(_PowerShellSDKRuntimeNativeRequestedRidList)' != ''" />
       <_PowerShellSDKRuntimeNativeUnsupportedRid Include="@(_PowerShellSDKRuntimeNativeRequestedRid)"
-                                                 Condition="'%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'win-x64' and '%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'win-arm64' and '%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'linux-x64' and '%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'linux-arm64' and '%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'osx-x64' and '%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'osx-arm64'" />
+                                                 Condition="'%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'win-x64' and '%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'win-arm64' and '%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'linux-x64' and '%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'linux-arm' and '%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'linux-arm64' and '%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'osx-x64' and '%(_PowerShellSDKRuntimeNativeRequestedRid.Identity)' != 'osx-arm64'" />
       <_PowerShellSDKRuntimeNativeSelectedRid Include="@(_PowerShellSDKRuntimeNativeSupportedRid)"
                                               Condition="'$(_PowerShellSDKRuntimeNativeRequestedRidList)' == '' or $([System.String]::Copy(';$(_PowerShellSDKRuntimeNativeRequestedRidList);').Contains(';%(_PowerShellSDKRuntimeNativeSupportedRid.Identity);')) == 'True'">
         <RelativeDirectory>runtimes/%(_PowerShellSDKRuntimeNativeSupportedRid.Identity)/native</RelativeDirectory>
@@ -777,6 +781,10 @@
       RuntimeConfigPath="$(PublishDir)runtimes/linux-x64/native/pwsh.runtimeconfig.json"
       ApplicationRuntimeConfigPath="$(PublishDir)$(AssemblyName).runtimeconfig.json"
       Condition="Exists('$(PublishDir)runtimes/linux-x64/native/pwsh.runtimeconfig.json')" />
+    <PowerShellSDKRewriteSelfContainedRuntimeConfig
+      RuntimeConfigPath="$(PublishDir)runtimes/linux-arm/native/pwsh.runtimeconfig.json"
+      ApplicationRuntimeConfigPath="$(PublishDir)$(AssemblyName).runtimeconfig.json"
+      Condition="Exists('$(PublishDir)runtimes/linux-arm/native/pwsh.runtimeconfig.json')" />
     <PowerShellSDKRewriteSelfContainedRuntimeConfig
       RuntimeConfigPath="$(PublishDir)runtimes/linux-arm64/native/pwsh.runtimeconfig.json"
       ApplicationRuntimeConfigPath="$(PublishDir)$(AssemblyName).runtimeconfig.json"

--- a/eng/Validate-PowerShellSdkPackage.ps1
+++ b/eng/Validate-PowerShellSdkPackage.ps1
@@ -15,7 +15,9 @@ param(
 
   [string] $PackageId = 'Devolutions.PowerShell.SDK',
 
-  [string] $PackageVendorName = 'Devolutions'
+  [string] $PackageVendorName = 'Devolutions',
+
+  [switch] $SkipRuntimeExecution
 )
 
 Set-StrictMode -Version 3.0
@@ -1063,15 +1065,17 @@ if (ps.HadErrors)
       }
       if ($Layout.ExpectRootAppHost) {
         Assert-AppHostOutput -Directory $ProbeOutputDirectory -ExecutableName $ExecutableName -Description $Description
-        $RootPwshPath = Join-Path $ProbeOutputDirectory $ExecutableName
-        [void] (Invoke-PwshVersionCheck -PwshPath $RootPwshPath -ExpectedVersion $PowerShellVersion)
-        Invoke-PwshModuleProbe -PwshPath $RootPwshPath -ModuleRoot (Join-Path $ProbeOutputDirectory 'Modules')
+        if (-not $SkipRuntimeExecution) {
+          $RootPwshPath = Join-Path $ProbeOutputDirectory $ExecutableName
+          [void] (Invoke-PwshVersionCheck -PwshPath $RootPwshPath -ExpectedVersion $PowerShellVersion)
+          Invoke-PwshModuleProbe -PwshPath $RootPwshPath -ModuleRoot (Join-Path $ProbeOutputDirectory 'Modules')
+        }
       }
       if ($Layout.ExpectRuntimeNativeAppHost) {
         foreach ($RuntimeNativeRid in $RuntimeNativeValidationRids) {
           $RuntimeNativeExecutableName = if ($RuntimeNativeRid -like 'win-*') { 'pwsh.exe' } else { 'pwsh' }
           $RuntimeNativePwshPath = Assert-RuntimeNativeAppHostOutput -Directory $ProbeOutputDirectory -RuntimeIdentifier $RuntimeNativeRid -ExecutableName $RuntimeNativeExecutableName -SelfContained $false -Description "$Description [$RuntimeNativeRid]"
-          if ($RuntimeNativeRid -eq $CurrentRuntimeIdentifier) {
+          if ($RuntimeNativeRid -eq $CurrentRuntimeIdentifier -and -not $SkipRuntimeExecution) {
             [void] (Invoke-PwshVersionCheck -PwshPath $RuntimeNativePwshPath -ExpectedVersion $PowerShellVersion)
             Invoke-PwshModuleProbe -PwshPath $RuntimeNativePwshPath -ModuleRoot (Join-Path $ProbeOutputDirectory 'Modules')
           }
@@ -1672,7 +1676,7 @@ foreach (PSObject result in ps.Invoke())
   foreach ($RuntimeNativeRid in $RuntimeNativeValidationRids) {
     $RuntimeNativeExecutableName = if ($RuntimeNativeRid -like 'win-*') { 'pwsh.exe' } else { 'pwsh' }
     $RuntimeNativePwshPath = Assert-RuntimeNativeAppHostOutput -Directory $OutputDirectory -RuntimeIdentifier $RuntimeNativeRid -ExecutableName $RuntimeNativeExecutableName -SelfContained $false -Description "Sample app output [$RuntimeNativeRid]"
-    if ($RuntimeNativeRid -eq $RuntimeIdentifier) {
+    if ($RuntimeNativeRid -eq $RuntimeIdentifier -and -not $SkipRuntimeExecution) {
       [void] (Invoke-PwshVersionCheck -PwshPath $RuntimeNativePwshPath -ExpectedVersion $PowerShellVersion)
       Invoke-PwshModuleProbe -PwshPath $RuntimeNativePwshPath -ModuleRoot (Join-Path $OutputDirectory 'Modules')
       Invoke-PwshStartJobProbe -PwshPath $RuntimeNativePwshPath
@@ -1725,13 +1729,15 @@ foreach (PSObject result in ps.Invoke())
   Assert-LocalizedResourcePresent -Directory $OutputDirectory -RelativePath $RepresentativeLocalizedResourcePath -Description 'Sample app output with localized resources opt-in'
   Assert-FileContentMatches -ExpectedPath $RepresentativeLocalizedResourcePackagePath -ActualPath $OutputLocalizedResourcePath -Description 'Sample app output localized resource opt-in'
 
-  $AppOutput = & dotnet run --project $ProjectPath --no-build
-  if ($LASTEXITCODE -ne 0) {
-    throw "Sample app failed with exit code $LASTEXITCODE"
-  }
-  $AppVersion = [string] ($AppOutput | Select-Object -Last 1)
-  if ($AppVersion.Trim() -ne $PowerShellVersion) {
-    throw "Sample app imported PowerShell SDK version '$AppVersion', expected '$PowerShellVersion'"
+  if (-not $SkipRuntimeExecution) {
+    $AppOutput = & dotnet run --project $ProjectPath --no-build
+    if ($LASTEXITCODE -ne 0) {
+      throw "Sample app failed with exit code $LASTEXITCODE"
+    }
+    $AppVersion = [string] ($AppOutput | Select-Object -Last 1)
+    if ($AppVersion.Trim() -ne $PowerShellVersion) {
+      throw "Sample app imported PowerShell SDK version '$AppVersion', expected '$PowerShellVersion'"
+    }
   }
 
   Invoke-AppHostLayoutMatrixProbe -ValidationRoot $ValidationRoot -PackageDirectoryPath $PackageDirectoryPath -PackageId $PackageId -PackageVersion $PackageVersion -SampleTargetFramework $SampleTargetFramework -TargetFramework $TargetFramework -RuntimeAssetGroup $RuntimeAssetGroup -CurrentRuntimeIdentifier $RuntimeIdentifier -RuntimeNativeValidationRids $RuntimeNativeValidationRids -ExecutableName $ExecutableName -PowerShellVersion $PowerShellVersion -RestoredSdkPath $RestoredSdkPath -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -PSGalleryProbeModuleNames $PSGalleryProbeModuleNames
@@ -1748,7 +1754,7 @@ foreach (PSObject result in ps.Invoke())
   foreach ($RuntimeNativeRid in $RuntimeNativeValidationRids) {
     $RuntimeNativeExecutableName = if ($RuntimeNativeRid -like 'win-*') { 'pwsh.exe' } else { 'pwsh' }
     $RuntimeNativePwshPath = Assert-RuntimeNativeAppHostOutput -Directory $PublishDirectory -RuntimeIdentifier $RuntimeNativeRid -ExecutableName $RuntimeNativeExecutableName -SelfContained $true -Description "Sample self-contained publish output [$RuntimeNativeRid]"
-    if ($RuntimeNativeRid -eq $RuntimeIdentifier) {
+    if ($RuntimeNativeRid -eq $RuntimeIdentifier -and -not $SkipRuntimeExecution) {
       $PwshVersion = Invoke-PwshVersionCheck -PwshPath $RuntimeNativePwshPath -ExpectedVersion $PowerShellVersion
       Invoke-PwshModuleProbe -PwshPath $RuntimeNativePwshPath -ModuleRoot (Join-Path $PublishDirectory 'Modules')
       Invoke-PwshStartJobProbe -PwshPath $RuntimeNativePwshPath

--- a/scripts/Build-LocalPowerShellSdk.ps1
+++ b/scripts/Build-LocalPowerShellSdk.ps1
@@ -12,7 +12,7 @@ param(
 
   [string] $MultiPwshPackageId = 'Devolutions.MultiPwsh.Cli',
 
-  [string] $MultiPwshPackageVersion = '0.14.1',
+  [string] $MultiPwshPackageVersion = '0.14.2',
 
   [string] $MultiPwshPackageSource = 'https://api.nuget.org/v3/index.json',
 
@@ -85,6 +85,7 @@ function Get-PSBuildRuntime {
   switch ($Rid) {
     'win-x64' { return 'fxdependent-win-desktop' }
     'linux-x64' { return 'fxdependent-linux-x64' }
+    'linux-arm' { return 'fxdependent-linux-arm' }
     'linux-arm64' { return 'fxdependent-linux-arm64' }
     'osx-x64' { return 'fxdependent' }
     'osx-arm64' { return 'fxdependent' }

--- a/scripts/Build-LocalPowerShellSdk.ps1
+++ b/scripts/Build-LocalPowerShellSdk.ps1
@@ -85,6 +85,7 @@ function Get-PSBuildRuntime {
   switch ($Rid) {
     'win-x64' { return 'fxdependent-win-desktop' }
     'linux-x64' { return 'fxdependent-linux-x64' }
+    'linux-arm' { return 'fxdependent-linux-arm' }
     'linux-arm64' { return 'fxdependent-linux-arm64' }
     'osx-x64' { return 'fxdependent' }
     'osx-arm64' { return 'fxdependent' }


### PR DESCRIPTION
Wire linux-arm through the PowerShell SDK apphost matrix, package layout, runtime-native targets, validation, local build mapping, and README docs.

This is intentionally draft-ready until Devolutions.MultiPwsh.Cli publishes a package with a runtimes/linux-arm/native/multi-pwsh asset.