### PR TITLE
Fix linux-arm PowerShell SDK apphost build

### DIFF
--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -318,7 +318,7 @@ jobs:
             executable: pwsh
           - rid: linux-arm
             runner: ubuntu-24.04
-            psbuild-runtime: fxdependent-linux-arm
+            psbuild-runtime: linux-arm
             executable: pwsh
           - rid: linux-arm64
             runner: ubuntu-24.04-arm

--- a/scripts/Build-LocalPowerShellSdk.ps1
+++ b/scripts/Build-LocalPowerShellSdk.ps1
@@ -85,7 +85,7 @@ function Get-PSBuildRuntime {
   switch ($Rid) {
     'win-x64' { return 'fxdependent-win-desktop' }
     'linux-x64' { return 'fxdependent-linux-x64' }
-    'linux-arm' { return 'fxdependent-linux-arm' }
+    'linux-arm' { return 'linux-arm' }
     'linux-arm64' { return 'fxdependent-linux-arm64' }
     'osx-x64' { return 'fxdependent' }
     'osx-arm64' { return 'fxdependent' }


### PR DESCRIPTION
## Summary
- Map the PowerShell SDK `linux-arm` apphost job to upstream `Start-PSBuild` runtime `linux-arm`
- Keep the local SDK build helper aligned with the workflow mapping

## Validation
- Parsed `.github\workflows\powershell-sdk.yml` as YAML
- Compared workflow `psbuild-runtime` values and local `Get-PSBuildRuntime` values against the pinned `pwsh-src` `Start-PSBuild` `ValidateSet`
- Ran `git diff --check`