### PR TITLE
Fix PowerShell release dry-run validation

### DIFF
--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -1473,18 +1473,18 @@ jobs:
             throw "Invalid SDK package version '$SdkPackageVersion', expected X.Y.Z.R."
           }
 
-          $ValidateArguments = @(
-            '-PackageDirectory', './sdk-package',
-            '-PowerShellVersion', $Env:POWERSHELL_VERSION,
-            '-PackageVersion', $SdkPackageVersion,
-            '-TargetFramework', $TargetFramework,
-            '-RuntimeIdentifier', '${{matrix.rid}}',
-            '-PackageId', $Env:SDK_PACKAGE_ID,
-            '-PackageVendorName', $Env:SDK_VENDOR_NAME
-          )
+          $ValidateArguments = @{
+            PackageDirectory = './sdk-package'
+            PowerShellVersion = $Env:POWERSHELL_VERSION
+            PackageVersion = $SdkPackageVersion
+            TargetFramework = $TargetFramework
+            RuntimeIdentifier = '${{matrix.rid}}'
+            PackageId = $Env:SDK_PACKAGE_ID
+            PackageVendorName = $Env:SDK_VENDOR_NAME
+          }
           [bool] $SkipRuntimeExecution = $false
           if ([System.Boolean]::TryParse('${{matrix.skip-runtime-execution}}', [ref] $SkipRuntimeExecution) -and $SkipRuntimeExecution) {
-            $ValidateArguments += '-SkipRuntimeExecution'
+            $ValidateArguments.SkipRuntimeExecution = $true
           }
 
           ./eng/Validate-PowerShellSdkPackage.ps1 @ValidateArguments

--- a/eng/Validate-PowerShellSdkPackage.ps1
+++ b/eng/Validate-PowerShellSdkPackage.ps1
@@ -1127,6 +1127,20 @@ function Assert-RuntimeConfigMode {
   }
 }
 
+function Test-RuntimeConfigSelfContained {
+  param(
+    [Parameter(Mandatory)]
+    [string] $RuntimeConfigPath
+  )
+
+  if (-not (Test-Path $RuntimeConfigPath -PathType Leaf)) {
+    throw "Runtimeconfig file does not exist: $RuntimeConfigPath"
+  }
+
+  $RuntimeConfig = Get-Content -LiteralPath $RuntimeConfigPath -Raw
+  return $RuntimeConfig -match '"includedFrameworks"\s*:'
+}
+
 function Invoke-PwshVersionCheck {
   param(
     [Parameter(Mandatory)]
@@ -1661,13 +1675,14 @@ foreach (PSObject result in ps.Invoke())
       throw "Restored SDK package is missing expected file: $RestoredPath"
     }
   }
+  $FrameworkDependentAppHostSelfContained = Test-RuntimeConfigSelfContained -RuntimeConfigPath (Join-Path $RestoredSdkPath "tools/apphost/$RuntimeIdentifier/pwsh.runtimeconfig.json")
   $RepresentativeLocalizedResourcePath = Get-RepresentativeLocalizedResourcePath -RestoredSdkPath $RestoredSdkPath -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework
   $RepresentativeLocalizedResourcePackagePath = Join-Path $RestoredSdkPath "buildTransitive/localized-resources/$RuntimeAssetGroup/lib/$TargetFramework/$RepresentativeLocalizedResourcePath"
 
   Invoke-DotNet @('build', $ProjectPath, '--no-restore', '--nologo', '--verbosity', 'minimal')
 
   $OutputDirectory = Join-Path $SampleDirectory (Join-Path 'bin' (Join-Path 'Debug' (Join-Path $SampleTargetFramework $RuntimeIdentifier)))
-  Assert-SharedPowerShellOutput -Directory $OutputDirectory -SelfContained $false -Description 'Sample app output'
+  Assert-SharedPowerShellOutput -Directory $OutputDirectory -SelfContained $FrameworkDependentAppHostSelfContained -Description 'Sample app output'
   Assert-PowerShellConfig -Directory $OutputDirectory -ExpectedExecutionPolicy 'Bypass' -Description 'Sample app output'
   Assert-NoRootRuntimeNativeAppHostOutput -Directory $OutputDirectory -ExecutableName $ExecutableName -Description 'Sample app output'
   Assert-SharedPowerShellRuntimeLibPreserved -RestoredSdkPath $RestoredSdkPath -Directory $OutputDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'Sample app output'
@@ -1764,7 +1779,7 @@ foreach (PSObject result in ps.Invoke())
   $FrameworkDependentPublishDirectory = Join-Path $SampleDirectory (Join-Path 'bin' (Join-Path 'Release' (Join-Path $SampleTargetFramework (Join-Path $RuntimeIdentifier 'publish-framework-dependent'))))
   Remove-Item $FrameworkDependentPublishDirectory -Recurse -Force -ErrorAction SilentlyContinue
   Invoke-DotNet @('publish', $ProjectPath, '--nologo', '--verbosity', 'minimal', '-c', 'Release', '-r', $RuntimeIdentifier, '--self-contained', 'false', '-o', $FrameworkDependentPublishDirectory)
-  Assert-SharedPowerShellOutput -Directory $FrameworkDependentPublishDirectory -SelfContained $false -Description 'Sample framework-dependent publish output'
+  Assert-SharedPowerShellOutput -Directory $FrameworkDependentPublishDirectory -SelfContained $FrameworkDependentAppHostSelfContained -Description 'Sample framework-dependent publish output'
   Assert-PowerShellConfig -Directory $FrameworkDependentPublishDirectory -ExpectedExecutionPolicy 'Bypass' -Description 'Sample framework-dependent publish output'
   Assert-NoRootRuntimeNativeAppHostOutput -Directory $FrameworkDependentPublishDirectory -ExecutableName $ExecutableName -Description 'Sample framework-dependent publish output'
   Assert-SharedPowerShellRuntimeLibPreserved -RestoredSdkPath $RestoredSdkPath -Directory $FrameworkDependentPublishDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'Sample framework-dependent publish output'
@@ -1822,7 +1837,7 @@ foreach (PSObject result in ps.Invoke())
     $PSGalleryPublishDirectory,
     "/p:PowerShellSDKPSGalleryModules=$PSGallerySubsetModuleNamesPropertyValue"
   )
-  Assert-SharedPowerShellOutput -Directory $PSGalleryPublishDirectory -SelfContained $false -Description 'Sample PSGallery publish output'
+  Assert-SharedPowerShellOutput -Directory $PSGalleryPublishDirectory -SelfContained $FrameworkDependentAppHostSelfContained -Description 'Sample PSGallery publish output'
   Assert-PowerShellConfig -Directory $PSGalleryPublishDirectory -ExpectedExecutionPolicy 'Bypass' -Description 'Sample PSGallery publish output'
   Assert-NoRootRuntimeNativeAppHostOutput -Directory $PSGalleryPublishDirectory -ExecutableName $ExecutableName -Description 'Sample PSGallery publish output'
   Assert-SharedPowerShellRuntimeLibPreserved -RestoredSdkPath $RestoredSdkPath -Directory $PSGalleryPublishDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'Sample PSGallery publish output'
@@ -1849,7 +1864,7 @@ foreach (PSObject result in ps.Invoke())
     $LocalizedPublishDirectory,
     '/p:PowerShellSDKLocalizedResources=Copy'
   )
-  Assert-SharedPowerShellOutput -Directory $LocalizedPublishDirectory -SelfContained $false -Description 'Sample localized resource publish output'
+  Assert-SharedPowerShellOutput -Directory $LocalizedPublishDirectory -SelfContained $FrameworkDependentAppHostSelfContained -Description 'Sample localized resource publish output'
   Assert-LocalizedResourcePresent -Directory $LocalizedPublishDirectory -RelativePath $RepresentativeLocalizedResourcePath -Description 'Sample localized resource publish output'
   Assert-FileContentMatches -ExpectedPath $RepresentativeLocalizedResourcePackagePath -ActualPath (Join-Path $LocalizedPublishDirectory $RepresentativeLocalizedResourcePath) -Description 'Sample localized resource publish output'
 

--- a/eng/Validate-PowerShellSdkPackage.ps1
+++ b/eng/Validate-PowerShellSdkPackage.ps1
@@ -1788,7 +1788,7 @@ foreach (PSObject result in ps.Invoke())
   foreach ($RuntimeNativeRid in $RuntimeNativeValidationRids) {
     $RuntimeNativeExecutableName = if ($RuntimeNativeRid -like 'win-*') { 'pwsh.exe' } else { 'pwsh' }
     $RuntimeNativePwshPath = Assert-RuntimeNativeAppHostOutput -Directory $FrameworkDependentPublishDirectory -RuntimeIdentifier $RuntimeNativeRid -ExecutableName $RuntimeNativeExecutableName -SelfContained $false -Description "Sample framework-dependent publish output [$RuntimeNativeRid]"
-    if ($RuntimeNativeRid -eq $RuntimeIdentifier) {
+    if ($RuntimeNativeRid -eq $RuntimeIdentifier -and -not $SkipRuntimeExecution) {
       [void] (Invoke-PwshVersionCheck -PwshPath $RuntimeNativePwshPath -ExpectedVersion $PowerShellVersion)
       Invoke-PwshStartJobProbe -PwshPath $RuntimeNativePwshPath
     }
@@ -1816,8 +1816,10 @@ foreach (PSObject result in ps.Invoke())
     "/p:PowerShellSDKPSGalleryModules=All"
   )
   Assert-PSGalleryModulesPresent -Directory $OutputDirectory -ModuleNames $PSGalleryProbeModuleNames -Description 'Sample app output with PSGallery opt-in'
-  $OutputRuntimeNativePwshPath = Join-Path $OutputDirectory "runtimes/$RuntimeIdentifier/native/$ExecutableName"
-  Invoke-PwshPSGalleryModuleProbe -PwshPath $OutputRuntimeNativePwshPath -ModuleRoot (Join-Path $OutputDirectory 'Modules') -ModuleNames $PSGalleryProbeModuleNames
+  if (-not $SkipRuntimeExecution) {
+    $OutputRuntimeNativePwshPath = Join-Path $OutputDirectory "runtimes/$RuntimeIdentifier/native/$ExecutableName"
+    Invoke-PwshPSGalleryModuleProbe -PwshPath $OutputRuntimeNativePwshPath -ModuleRoot (Join-Path $OutputDirectory 'Modules') -ModuleNames $PSGalleryProbeModuleNames
+  }
 
   $PSGalleryPublishDirectory = Join-Path $SampleDirectory (Join-Path 'bin' (Join-Path 'Release' (Join-Path $SampleTargetFramework (Join-Path $RuntimeIdentifier 'publish-psgallery'))))
   Remove-Item $PSGalleryPublishDirectory -Recurse -Force -ErrorAction SilentlyContinue
@@ -1844,7 +1846,9 @@ foreach (PSObject result in ps.Invoke())
   Assert-PSGalleryModulesPresent -Directory $PSGalleryPublishDirectory -ModuleNames $PSGallerySubsetModuleNames -Description 'Sample PSGallery publish output'
   Assert-PSGalleryModulesAbsent -Directory $PSGalleryPublishDirectory -ModuleNames $UnexpectedPSGallerySubsetModuleNames -Description 'Sample PSGallery publish output'
   $PSGalleryPublishRuntimeNativePwshPath = Assert-RuntimeNativeAppHostOutput -Directory $PSGalleryPublishDirectory -RuntimeIdentifier $RuntimeIdentifier -ExecutableName $ExecutableName -SelfContained $false -Description "Sample PSGallery publish output [$RuntimeIdentifier]"
-  [void] (Invoke-PwshVersionCheck -PwshPath $PSGalleryPublishRuntimeNativePwshPath -ExpectedVersion $PowerShellVersion)
+  if (-not $SkipRuntimeExecution) {
+    [void] (Invoke-PwshVersionCheck -PwshPath $PSGalleryPublishRuntimeNativePwshPath -ExpectedVersion $PowerShellVersion)
+  }
 
   $LocalizedPublishDirectory = Join-Path $SampleDirectory (Join-Path 'bin' (Join-Path 'Release' (Join-Path $SampleTargetFramework (Join-Path $RuntimeIdentifier 'publish-localized'))))
   Remove-Item $LocalizedPublishDirectory -Recurse -Force -ErrorAction SilentlyContinue
@@ -1869,9 +1873,13 @@ foreach (PSObject result in ps.Invoke())
   Assert-FileContentMatches -ExpectedPath $RepresentativeLocalizedResourcePackagePath -ActualPath (Join-Path $LocalizedPublishDirectory $RepresentativeLocalizedResourcePath) -Description 'Sample localized resource publish output'
 
   Write-Host "Validated $PackageId $PackageVersion from $($Package.FullName)"
-  Write-Host "Sample app imported vendored PowerShell SDK $($AppVersion.Trim())"
-  Write-Host "Sample self-contained publish runtime-native apphost reported PowerShell $PwshVersion"
-  Write-Host "Sample framework-dependent publish runtime-native apphost reported PowerShell $PowerShellVersion"
+  if ($SkipRuntimeExecution) {
+    Write-Host "Skipped runtime execution probes for $RuntimeIdentifier."
+  } else {
+    Write-Host "Sample app imported vendored PowerShell SDK $($AppVersion.Trim())"
+    Write-Host "Sample self-contained publish runtime-native apphost reported PowerShell $PwshVersion"
+    Write-Host "Sample framework-dependent publish runtime-native apphost reported PowerShell $PowerShellVersion"
+  }
 } finally {
   Set-Location $PreviousLocation
   $Env:NUGET_PACKAGES = $PreviousNuGetPackages


### PR DESCRIPTION
## Summary
- Fix SDK validation script invocation in `powershell-sdk.yml` by using hashtable splatting for named parameters.
- Update SDK validation to respect packaged apphost runtimeconfig mode, including the linux-arm self-contained apphost exception.
- Skip linux-arm runtime execution probes consistently when validation is cross-building on an x64 runner.

## Validation
- Parsed updated PowerShell validator script.
- Parsed `release.yml`, `powershell-sdk.yml`, and `powershell-cli.yml` as YAML.
- Successful branch release dry run: https://github.com/Devolutions/pwsh-distro/actions/runs/29025225188