### PR TITLE
Bump PowerShell to 7.6.4

### DIFF
--- a/.agents/skills/powershell-pin-audit/SKILL.md
+++ b/.agents/skills/powershell-pin-audit/SKILL.md
@@ -7,7 +7,7 @@ description: Audits coordinated PowerShell version pins across workflows, .gitmo
 
 Use this skill when updating the pinned PowerShell version, reviewing a PowerShell release bump, or checking that the repository's coordinated PowerShell pins still agree.
 
-The audit checks the primary `.github/workflows/powershell-sdk.yml` workflow, the secondary `.github/workflows/powershell.yml` workflow, `.gitmodules`, the README "Current pins" table, and `pwsh-src/PowerShell.Common.props` when the submodule is available.
+The audit checks the primary `.github/workflows/powershell-sdk.yml` workflow, the secondary `.github/workflows/powershell-cli.yml` workflow, `.gitmodules`, the README "Current pins" table, and `pwsh-src/PowerShell.Common.props` when the submodule is available.
 
 ## Prerequisites
 
@@ -41,6 +41,7 @@ pwsh .\.agents\skills\powershell-pin-audit\scripts\Test-PowerShellPins.ps1 -Repo
 - `POWERSHELL_RELEASE_TAG` is `v$POWERSHELL_VERSION`.
 - `POWERSHELL_UPSTREAM_TAG` is `upstream/$POWERSHELL_RELEASE_TAG`.
 - `POWERSHELL_SOURCE_REF` is `downstream/$POWERSHELL_RELEASE_TAG`.
+- The CLI workflow SDK package ID, version, and revision match the SDK workflow defaults.
 - `.gitmodules` tracks the same downstream branch as `POWERSHELL_SOURCE_REF`.
 - README "Current pins" records the same upstream release, downstream source ref, upstream base tag, and target framework.
 - If `pwsh-src/PowerShell.Common.props` exists, README's target framework matches its `<TargetFramework>` value.

--- a/.agents/skills/powershell-pin-audit/scripts/Test-PowerShellPins.ps1
+++ b/.agents/skills/powershell-pin-audit/scripts/Test-PowerShellPins.ps1
@@ -92,7 +92,7 @@ function Assert-Equal {
 }
 
 $SdkWorkflow = '.github\workflows\powershell-sdk.yml'
-$DistributionWorkflow = '.github\workflows\powershell.yml'
+$DistributionWorkflow = '.github\workflows\powershell-cli.yml'
 $SdkPins = Get-PowerShellWorkflowPins $SdkWorkflow
 $DistributionPins = Get-PowerShellWorkflowPins $DistributionWorkflow
 
@@ -114,6 +114,17 @@ if ($SdkPackageRevision -notmatch '^\d+$') {
   Add-AuditError "SDK_PACKAGE_REVISION in $SdkWorkflow must be numeric, found '$SdkPackageRevision'."
 }
 $SdkPackageVersion = "$Version.$SdkPackageRevision"
+$DistributionWorkflowText = Get-RepositoryFileText $DistributionWorkflow
+$DistributionSdkPackageId = Get-YamlScalar -Text $DistributionWorkflowText -Name 'SDK_PACKAGE_ID' -FileName $DistributionWorkflow
+$DistributionSdkPackageVersion = Get-YamlScalar -Text $DistributionWorkflowText -Name 'SDK_PACKAGE_VERSION' -FileName $DistributionWorkflow
+$DistributionSdkPackageRevision = Get-YamlScalar -Text $DistributionWorkflowText -Name 'SDK_PACKAGE_REVISION' -FileName $DistributionWorkflow
+if ($DistributionSdkPackageRevision -notmatch '^\d+$') {
+  Add-AuditError "SDK_PACKAGE_REVISION in $DistributionWorkflow must be numeric, found '$DistributionSdkPackageRevision'."
+}
+
+Assert-Equal -Actual $DistributionSdkPackageId -Expected $SdkPackageId -Description "SDK_PACKAGE_ID in $DistributionWorkflow"
+Assert-Equal -Actual $DistributionSdkPackageRevision -Expected $SdkPackageRevision -Description "SDK_PACKAGE_REVISION in $DistributionWorkflow"
+Assert-Equal -Actual $DistributionSdkPackageVersion -Expected $SdkPackageVersion -Description "SDK_PACKAGE_VERSION in $DistributionWorkflow"
 
 Assert-Equal -Actual $ReleaseTag -Expected "v$Version" -Description 'POWERSHELL_RELEASE_TAG'
 Assert-Equal -Actual $UpstreamTag -Expected "upstream/$ReleaseTag" -Description 'POWERSHELL_UPSTREAM_TAG'

--- a/.agents/skills/powershell-release-bump/SKILL.md
+++ b/.agents/skills/powershell-release-bump/SKILL.md
@@ -7,7 +7,7 @@ description: Coordinates PowerShell release bumps across workflow env pins, .git
 
 Use this skill when moving this repository to a new upstream PowerShell release or reviewing a PR that claims to bump PowerShell.
 
-This repository requires a coordinated bump across `.github\workflows\powershell-sdk.yml`, `.github\workflows\powershell.yml`, `.gitmodules`, the `pwsh-src` submodule pointer, and README's "Current pins" table. Keep `POWERSHELL_SOURCE_REF` separate from `POWERSHELL_RELEASE_TAG`: the source ref points to `downstream/vX.Y.Z`, while the release tag remains the upstream `vX.Y.Z` value.
+This repository requires a coordinated bump across `.github\workflows\powershell-sdk.yml`, `.github\workflows\powershell-cli.yml`, `.gitmodules`, the `pwsh-src` submodule pointer, and README's "Current pins" table. Keep `POWERSHELL_SOURCE_REF` separate from `POWERSHELL_RELEASE_TAG`: the source ref points to `downstream/vX.Y.Z`, while the release tag remains the upstream `vX.Y.Z` value.
 
 ## Prerequisites
 

--- a/.agents/skills/powershell-release-bump/scripts/Set-PowerShellReleasePins.ps1
+++ b/.agents/skills/powershell-release-bump/scripts/Set-PowerShellReleasePins.ps1
@@ -5,6 +5,8 @@ param(
 
   [string] $TargetFramework,
 
+  [string] $SdkPackageRevision = '0',
+
   [string] $RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..\..')).Path
 )
 
@@ -38,7 +40,10 @@ function Set-RepositoryFileText {
 
   $Path = Get-RepositoryPath $RelativePath
   if ($PSCmdlet.ShouldProcess($RelativePath, 'Update PowerShell release pins')) {
-    Set-Content -LiteralPath $Path -Value $Text -Encoding utf8NoBOM
+    [System.IO.File]::WriteAllText(
+      $Path,
+      $Text,
+      [System.Text.UTF8Encoding]::new($false))
   }
 }
 
@@ -106,6 +111,11 @@ if ($NormalizedVersion -notmatch '^\d+\.\d+\.\d+$') {
   throw "Version must be in X.Y.Z or vX.Y.Z form. Received '$Version'."
 }
 
+$SdkPackageRevision = $SdkPackageRevision.Trim()
+if ($SdkPackageRevision -notmatch '^\d+$') {
+  throw "SdkPackageRevision must be a non-negative integer. Received '$SdkPackageRevision'."
+}
+
 if (-not $TargetFramework) {
   $TargetFramework = Get-PowerShellTargetFramework
 }
@@ -113,9 +123,11 @@ if (-not $TargetFramework) {
 $ReleaseTag = "v$NormalizedVersion"
 $UpstreamTag = "upstream/$ReleaseTag"
 $SourceRef = "downstream/$ReleaseTag"
+$SdkPackageVersion = "$NormalizedVersion.$SdkPackageRevision"
 $ReadmeReleaseValue = "``$NormalizedVersion`` / ``$ReleaseTag``"
 $ReadmeSourceRefValue = "``$SourceRef`` based on ``$UpstreamTag``"
 $ReadmeTargetFrameworkValue = "``$TargetFramework``"
+$ReadmeSdkPackageDefaultValue = "``$SdkPackageVersion``"
 
 $WorkflowPins = [ordered]@{
   POWERSHELL_VERSION = $NormalizedVersion
@@ -124,10 +136,14 @@ $WorkflowPins = [ordered]@{
   POWERSHELL_SOURCE_REF = $SourceRef
 }
 
-foreach ($WorkflowPath in @('.github\workflows\powershell-sdk.yml', '.github\workflows\powershell.yml')) {
+foreach ($WorkflowPath in @('.github\workflows\powershell-sdk.yml', '.github\workflows\powershell-cli.yml')) {
   $WorkflowText = Get-RepositoryFileText $WorkflowPath
   foreach ($Pin in $WorkflowPins.GetEnumerator()) {
     $WorkflowText = Set-YamlEnvValue -Text $WorkflowText -Name $Pin.Key -Value $Pin.Value -FileName $WorkflowPath
+  }
+  $WorkflowText = Set-YamlEnvValue -Text $WorkflowText -Name 'SDK_PACKAGE_REVISION' -Value $SdkPackageRevision -FileName $WorkflowPath
+  if ($WorkflowPath -eq '.github\workflows\powershell-cli.yml') {
+    $WorkflowText = Set-YamlEnvValue -Text $WorkflowText -Name 'SDK_PACKAGE_VERSION' -Value $SdkPackageVersion -FileName $WorkflowPath
   }
   Set-RepositoryFileText -RelativePath $WorkflowPath -Text $WorkflowText
 }
@@ -156,6 +172,11 @@ $ReadmeText = Set-RegexValue `
   -Pattern '^(\| PowerShell target framework \| )`[^`]+`( \|\r?)$' `
   -ReplacementValue $ReadmeTargetFrameworkValue `
   -Description 'README PowerShell target framework row'
+$ReadmeText = Set-RegexValue `
+  -Text $ReadmeText `
+  -Pattern '^(\| PowerShell SDK package \| `[^`]+` / )`[^`]+`( workflow default; `[^`]+` latest published package \|\r?)$' `
+  -ReplacementValue $ReadmeSdkPackageDefaultValue `
+  -Description 'README PowerShell SDK package workflow default'
 Set-RepositoryFileText -RelativePath 'README.md' -Text $ReadmeText
 
 Write-Output "PowerShellVersion=$NormalizedVersion"
@@ -163,4 +184,5 @@ Write-Output "PowerShellReleaseTag=$ReleaseTag"
 Write-Output "PowerShellUpstreamTag=$UpstreamTag"
 Write-Output "PowerShellSourceRef=$SourceRef"
 Write-Output "PowerShellTargetFramework=$TargetFramework"
+Write-Output "SdkPackageVersion=$SdkPackageVersion"
 Write-Output 'NextStep=git submodule update --remote pwsh-src && git add pwsh-src'

--- a/.github/workflows/powershell-cli.yml
+++ b/.github/workflows/powershell-cli.yml
@@ -64,13 +64,13 @@ permissions:
   actions: read
   contents: read
 env:
-  POWERSHELL_VERSION: "7.6.3"
-  POWERSHELL_RELEASE_TAG: "v7.6.3"
-  POWERSHELL_UPSTREAM_TAG: "upstream/v7.6.3"
+  POWERSHELL_VERSION: "7.6.4"
+  POWERSHELL_RELEASE_TAG: "v7.6.4"
+  POWERSHELL_UPSTREAM_TAG: "upstream/v7.6.4"
   POWERSHELL_SOURCE_REPOSITORY: ${{ github.repository }}
-  POWERSHELL_SOURCE_REF: "downstream/v7.6.3"
+  POWERSHELL_SOURCE_REF: "downstream/v7.6.4"
   SDK_PACKAGE_ID: "Devolutions.PowerShell.SDK"
-  SDK_PACKAGE_VERSION: "7.6.3.0"
+  SDK_PACKAGE_VERSION: "7.6.4.0"
   SDK_PACKAGE_REVISION: "0"
   SDK_PACKAGE_SOURCE: "https://api.nuget.org/v3/index.json"
 jobs:

--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -106,11 +106,11 @@ permissions:
   contents: read
 
 env:
-  POWERSHELL_VERSION: "7.6.3"
-  POWERSHELL_RELEASE_TAG: "v7.6.3"
-  POWERSHELL_UPSTREAM_TAG: "upstream/v7.6.3"
+  POWERSHELL_VERSION: "7.6.4"
+  POWERSHELL_RELEASE_TAG: "v7.6.4"
+  POWERSHELL_UPSTREAM_TAG: "upstream/v7.6.4"
   POWERSHELL_SOURCE_REPOSITORY: ${{ github.repository }}
-  POWERSHELL_SOURCE_REF: "downstream/v7.6.3"
+  POWERSHELL_SOURCE_REF: "downstream/v7.6.4"
   POWERSHELL_VENDOR_NAME: "Devolutions"
   SDK_VENDOR_NAME: "Devolutions"
   SDK_PACKAGE_ID: "Devolutions.PowerShell.SDK"
@@ -1078,7 +1078,8 @@ jobs:
             -PackageId $Env:SDK_PACKAGE_ID `
             -VendorName $Env:SDK_VENDOR_NAME `
             -SourceBuiltAssemblyNames $SourceBuiltAssemblyNames `
-            -SourceBuiltAssemblyDirectoriesByPackagePath $SourceBuiltAssemblyDirectoriesByPackagePath
+            -SourceBuiltAssemblyDirectoriesByPackagePath $SourceBuiltAssemblyDirectoriesByPackagePath `
+            -SourceBuiltSdkProjectPath './src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj'
 
           $AnyAnyRuntimesDir = Join-Path $SdkStagePath "contentFiles/any/any/runtimes"
           Remove-Item $AnyAnyRuntimesDir -Recurse -Force -ErrorAction SilentlyContinue
@@ -1486,5 +1487,5 @@ jobs:
           if ([System.Boolean]::TryParse('${{matrix.skip-runtime-execution}}', [ref] $SkipRuntimeExecution) -and $SkipRuntimeExecution) {
             $ValidateArguments.SkipRuntimeExecution = $true
           }
-
+          ./eng/Validate-PowerShellSdkPackage.ps1 @ValidateArguments
           ./eng/Validate-PowerShellSdkPackage.ps1 @ValidateArguments

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "pwsh-src"]
 	path = pwsh-src
 	url = ./
-	branch = downstream/v7.6.3
+	branch = downstream/v7.6.4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent instructions
 
-This repository is a small GitHub Actions project for building PowerShell distribution artifacts. Treat `.github/workflows/powershell-sdk.yml` as the primary product surface and `.github/workflows/powershell.yml` as the secondary product surface.
+This repository is a small GitHub Actions project for building PowerShell distribution artifacts. Treat `.github/workflows/powershell-sdk.yml` as the primary product surface and `.github/workflows/powershell-cli.yml` as the secondary product surface.
 
 Keep version pins explicit in workflow `env` blocks. When updating PowerShell, update the PowerShell version, release tag, upstream tag, and source ref in both PowerShell workflows, verify the upstream target framework from `pwsh-src/PowerShell.Common.props`, and keep SDK packaging paths derived from that property instead of hardcoding `net*` folders. The version bump is four coordinated edits in one PR: the `POWERSHELL_*` env vars in both PowerShell workflows, the `branch = downstream/vX.Y.Z` line in `.gitmodules` (git does not expand variables there, so it must be edited literally), the `pwsh-src` submodule pointer on `master` (`git submodule update --remote pwsh-src && git add pwsh-src`), and the "Current pins" table in README.md.
 

--- a/README.md
+++ b/README.md
@@ -22,16 +22,16 @@ To build a local, current-RID SDK package for smoke testing outside Actions:
 .\scripts\Build-LocalPowerShellSdk.ps1 -Validate
 ```
 
-The local script writes under `output\local-sdk\<rid>\` and produces a single-RID validation package. The GitHub Actions SDK workflow remains the authoritative multi-RID package build. Pass `-SdkPackageVersion 7.6.3.2` to smoke-test the latest downstream package revision for the same upstream PowerShell release.
+The local script writes under `output\local-sdk\<rid>\` and produces a single-RID validation package. The GitHub Actions SDK workflow remains the authoritative multi-RID package build. Pass `-SdkPackageVersion 7.6.3.2` to smoke-test the latest published downstream package while the first 7.6.4 package is being prepared.
 
 ## Current pins
 
 | Component | Version |
 | --- | --- |
-| PowerShell upstream release | `7.6.3` / `v7.6.3` |
-| PowerShell downstream source ref | `downstream/v7.6.3` based on `upstream/v7.6.3` |
+| PowerShell upstream release | `7.6.4` / `v7.6.4` |
+| PowerShell downstream source ref | `downstream/v7.6.4` based on `upstream/v7.6.4` |
 | PowerShell target framework | `net10.0` |
-| PowerShell SDK package | `Devolutions.PowerShell.SDK` / `7.6.3.0` workflow default; `7.6.3.2` latest published package |
+| PowerShell SDK package | `Devolutions.PowerShell.SDK` / `7.6.4.0` workflow default; `7.6.3.2` latest published package |
 | Latest downstream release tag | `v7.6.3.2` |
 | Latest PowerShell CLI release assets | `PowerShell-7.6.3-<os>-<arch>.tar.gz` for Windows, macOS, and Linux on x64 and arm64 |
 | PowerShell SDK package source | `https://api.nuget.org/v3/index.json` |
@@ -239,5 +239,5 @@ The apphost output is intended for running scripts with the core built-in module
 The secondary PowerShell CLI workflow uses this same package-consumer path instead of rebuilding PowerShell from source. It creates a temporary .NET project, restores the pinned SDK package from the pinned package source or a workflow-built SDK artifact, enables root apphost and PSGallery module import, opts into localized resources when present, publishes self-contained for the matrix RID, removes the temporary host application files, validates the PowerShell layout, and archives the result as `.tar.gz` for every platform, including Windows. Windows archives additionally stage the matching `Microsoft.WindowsDesktop.App.Runtime.<rid>` payload so WPF/WinForms assemblies such as `PresentationFramework.dll`, `System.Windows.Forms.dll`, and `WindowsBase.dll` load from `$PSHOME`. For end-to-end dry runs outside `.github/workflows/release.yml`, pass `sdk_artifact_run_id` to `.github/workflows/powershell-cli.yml` so it downloads the `PowerShell-SDK-Release-X.Y.Z.R` artifact from a prior `.github/workflows/powershell-sdk.yml` run and repackages that workflow-built `.nupkg` instead of restoring from NuGet.org. If the artifact name does not include the SDK version, also pass `sdk_package_version`.
 
 During NuGet packing, upstream `Microsoft.PowerShell.SDK` content file/reference metadata can emit NU5100/NU5131 package analysis warnings. The SDK workflow treats package validation as the source of truth: the generated sample must restore only the vendored PowerShell package ID, build, publish framework-dependent and self-contained outputs, execute `pwsh`, and load copied built-in modules.
-
+Generated source checkouts and build artifacts are not part of this repository.
 Generated source checkouts and build artifacts are not part of this repository.

--- a/eng/Vendor-PowerShellSdkPackage.ps1
+++ b/eng/Vendor-PowerShellSdkPackage.ps1
@@ -20,7 +20,9 @@ param(
 
   [hashtable] $SourceBuiltAssemblyDirectoriesByPackagePath,
 
-  [string] $SourcePackageDirectory
+  [string] $SourcePackageDirectory,
+
+  [string] $SourceBuiltSdkProjectPath
 )
 
 Set-StrictMode -Version 3.0
@@ -247,6 +249,65 @@ function Add-ExternalDependenciesFromNuspec {
       -TargetFramework '' `
       -Id $DependencyId `
       -Version ([string] $Dependency.version)
+  }
+}
+
+function Get-PackageReferenceVersions {
+  param(
+    [Parameter(Mandatory)]
+    [string] $ProjectPath
+  )
+
+  if (-not (Test-Path -LiteralPath $ProjectPath -PathType Leaf)) {
+    throw "Source-built SDK project was not found: $ProjectPath"
+  }
+
+  [xml] $Project = Get-Content -LiteralPath $ProjectPath
+  $DependencyVersions = [ordered]@{}
+  foreach ($PackageReference in @($Project.SelectNodes("//*[local-name()='PackageReference']"))) {
+    $Id = $PackageReference.GetAttribute('Include')
+    $Version = $PackageReference.GetAttribute('Version')
+    if ([string]::IsNullOrWhiteSpace($Version)) {
+      $VersionElement = $PackageReference.SelectSingleNode("*[local-name()='Version']")
+      if ($VersionElement) {
+        $Version = $VersionElement.InnerText
+      }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($Id) -and -not [string]::IsNullOrWhiteSpace($Version)) {
+      $DependencyVersions[$Id] = $Version
+    }
+  }
+
+  return $DependencyVersions
+}
+
+function Set-SourceBuiltDependencyVersions {
+  param(
+    [Parameter(Mandatory)]
+    [System.Collections.Specialized.OrderedDictionary] $DependencyGroups,
+
+    [Parameter(Mandatory)]
+    [System.Collections.IDictionary] $SourceBuiltDependencyVersions
+  )
+
+  $AppliedDependencyIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  foreach ($Dependencies in @($DependencyGroups.Values)) {
+    foreach ($DependencyId in @($Dependencies.Keys)) {
+      if ($SourceBuiltDependencyVersions.Contains($DependencyId)) {
+        $Dependencies[$DependencyId] = [string] $SourceBuiltDependencyVersions[$DependencyId]
+        [void] $AppliedDependencyIds.Add($DependencyId)
+      }
+    }
+  }
+
+  $UnmatchedDependencyIds = @(
+    $SourceBuiltDependencyVersions.Keys |
+      Where-Object { -not $AppliedDependencyIds.Contains([string] $_) } |
+      Sort-Object
+  )
+  if ($UnmatchedDependencyIds.Count -gt 0) {
+    throw "Source-built SDK dependencies were not found in vendored package metadata: $($UnmatchedDependencyIds -join ', ')"
   }
 }
 
@@ -696,6 +757,12 @@ try {
       -NuspecPath (Get-NuspecPath -PackageRootPath $ExtractedPackageRoots[$EmbeddedPackageId]) `
       -EmbeddedIds $EmbeddedPackageIds `
       -DependencyGroups $DependencyGroups
+  }
+  if ($SourceBuiltSdkProjectPath) {
+    $SourceBuiltDependencyVersions = Get-PackageReferenceVersions -ProjectPath $SourceBuiltSdkProjectPath
+    Set-SourceBuiltDependencyVersions `
+      -DependencyGroups $DependencyGroups `
+      -SourceBuiltDependencyVersions $SourceBuiltDependencyVersions
   }
 
   Copy-PackagePayload -SourceRoot $ExtractedPackageRoots[$OriginalPackageId] -DestinationRoot $PackageRootPath

--- a/scripts/Build-LocalPowerShellSdk.ps1
+++ b/scripts/Build-LocalPowerShellSdk.ps1
@@ -529,7 +529,8 @@ try {
     -PackageId $PackageId `
     -VendorName $VendorName `
     -SourceBuiltAssemblyNames $SourceBuiltAssemblyNames `
-    -SourceBuiltAssemblyDirectoriesByPackagePath $SourceBuiltAssemblyDirectoriesByPackagePath
+    -SourceBuiltAssemblyDirectoriesByPackagePath $SourceBuiltAssemblyDirectoriesByPackagePath `
+    -SourceBuiltSdkProjectPath (Join-Path $PwshSourceRoot 'src\Microsoft.PowerShell.SDK\Microsoft.PowerShell.SDK.csproj')
 
   $AnyAnyRuntimesDir = Join-Path $SdkStagePath 'contentFiles\any\any\runtimes'
   Remove-Item $AnyAnyRuntimesDir -Recurse -Force -ErrorAction SilentlyContinue

--- a/scripts/Sync-PowerShellUpstream.ps1
+++ b/scripts/Sync-PowerShellUpstream.ps1
@@ -97,7 +97,13 @@ if ($SyncTags) {
   }
 
   if ($Dropped.Count -gt 0) {
-    Invoke-Git tag -d @($Dropped | ForEach-Object { $_ -replace '^refs/tags/','' })
+    foreach ($Tag in $Dropped) {
+      $ShortName = $Tag -replace '^refs/tags/',''
+      & git tag -d $ShortName
+      if ($LASTEXITCODE -ne 0) {
+        throw "git tag -d $ShortName failed with exit code $LASTEXITCODE"
+      }
+    }
   }
 
   Write-Host "Kept $($Kept.Count) upstream tag(s) matching '$TagIncludePattern'; dropped $($Dropped.Count) non-matching tag(s)."


### PR DESCRIPTION
## Summary
- Pin SDK and CLI workflows, submodule metadata, and README Current pins to PowerShell 7.6.4.
- Create and pin the ported `downstream/v7.6.4` source branch, including cryptography dependency servicing to 10.0.10.
- Repair release bump/audit tooling and derive vendored package dependency versions from the source-built SDK project.

## Validation
- Ran the coordinated pin audit with the initialized submodule.
- Parsed the updated workflow YAML and PowerShell scripts.
- Built and validated the local `win-x64` SDK package and consumer apphost layouts.