### PR TITLE
Bump PowerShell to 7.6.5

### DIFF
--- a/.agents/skills/powershell-release-bump/SKILL.md
+++ b/.agents/skills/powershell-release-bump/SKILL.md
@@ -58,13 +58,14 @@ The patch range is the source of truth. Carry all of its commits unless a newer 
 
 ### 2. Mirror and publish the upstream release tag
 
-Synchronize namespaced upstream tags, verify the target tag, and publish only that new mirror tag:
+Synchronize namespaced upstream tags, verify the target tag, and publish the refreshed upstream mirror branch plus the new mirror tag:
 
 ```powershell
 pwsh .\scripts\Sync-PowerShellUpstream.ps1 -SyncTags
 git rev-parse --verify "upstream/v$Version^{commit}"
 git show "upstream/v$Version:PowerShell.Common.props" |
   Select-String -Pattern 'TargetFramework'
+git push --force origin "refs/heads/upstream:refs/heads/upstream"
 git push origin "refs/tags/upstream/v$Version:refs/tags/upstream/v$Version"
 ```
 
@@ -79,11 +80,11 @@ pwsh .\scripts\New-PowerShellPatchBranch.ps1 -Version $Version
 $PatchWorktree = Join-Path $env:TEMP "pwsh-src-v$Version"
 git worktree add $PatchWorktree "downstream/v$Version"
 
-$PatchCommits = git rev-list --reverse "upstream/v$PreviousVersion..downstream/v$PreviousVersion"
-foreach ($PatchCommit in $PatchCommits) {
-  git -C $PatchWorktree cherry-pick $PatchCommit
+$PatchCommits = @(git rev-list --reverse "upstream/v$PreviousVersion..downstream/v$PreviousVersion")
+if ($PatchCommits.Count -gt 0) {
+  git -C $PatchWorktree cherry-pick @PatchCommits
   if ($LASTEXITCODE -ne 0) {
-    throw "Resolve the cherry-pick for $PatchCommit in $PatchWorktree before continuing."
+    throw "Resolve the cherry-pick in $PatchWorktree, then run 'git -C $PatchWorktree cherry-pick --continue'."
   }
 }
 ```
@@ -108,9 +109,18 @@ Validate the patched source, confirm it remains based on the target upstream tag
 
 ```powershell
 git -C $PatchWorktree diff --check
+if ($LASTEXITCODE -ne 0) {
+  throw "The patched source diff check failed."
+}
 git -C $PatchWorktree merge-base --is-ancestor "upstream/v$Version^{commit}" HEAD
+if ($LASTEXITCODE -ne 0) {
+  throw "downstream/v$Version is not based on upstream/v$Version."
+}
 git -C $PatchWorktree log --oneline "upstream/v$Version..HEAD"
 git push origin "downstream/v$Version"
+if ($LASTEXITCODE -ne 0) {
+  throw "Failed to publish downstream/v$Version."
+}
 ```
 
 ### 4. Update coordinated distribution pins
@@ -155,9 +165,21 @@ Get-Content -Raw .github\workflows\powershell-sdk.yml | ConvertFrom-Yaml | Out-N
 Get-Content -Raw .github\workflows\powershell-cli.yml | ConvertFrom-Yaml | Out-Null
 
 git -C pwsh-src rev-parse --verify "upstream/v$Version^{commit}"
+if ($LASTEXITCODE -ne 0) {
+  throw "pwsh-src is missing upstream/v$Version."
+}
 git -C pwsh-src merge-base --is-ancestor "upstream/v$Version^{commit}" HEAD
+if ($LASTEXITCODE -ne 0) {
+  throw "pwsh-src is not based on upstream/v$Version."
+}
 git --no-pager diff --check
+if ($LASTEXITCODE -ne 0) {
+  throw "The unstaged diff check failed."
+}
 git --no-pager diff --cached --check
+if ($LASTEXITCODE -ne 0) {
+  throw "The staged diff check failed."
+}
 git submodule status pwsh-src
 git status --short
 ```

--- a/.agents/skills/powershell-release-bump/SKILL.md
+++ b/.agents/skills/powershell-release-bump/SKILL.md
@@ -1,73 +1,181 @@
 ---
 name: powershell-release-bump
-description: Coordinates PowerShell release bumps across workflow env pins, .gitmodules, README current pins, and the pwsh-src submodule pointer.
+description: Upgrades to a new PowerShell release by mirroring its tag, porting downstream patches, publishing the downstream source branch, and coordinating workflow and submodule pins.
 ---
 
 # powershell release bump
 
-Use this skill when moving this repository to a new upstream PowerShell release or reviewing a PR that claims to bump PowerShell.
+Use this skill when moving this repository to a new upstream PowerShell release. It covers the full upgrade flow: mirror the upstream tag, create and patch the downstream source branch, update the submodule pin, and synchronize the workflow and documentation pins.
 
-This repository requires a coordinated bump across `.github\workflows\powershell-sdk.yml`, `.github\workflows\powershell-cli.yml`, `.gitmodules`, the `pwsh-src` submodule pointer, and README's "Current pins" table. Keep `POWERSHELL_SOURCE_REF` separate from `POWERSHELL_RELEASE_TAG`: the source ref points to `downstream/vX.Y.Z`, while the release tag remains the upstream `vX.Y.Z` value.
+Do not use this skill to merely check existing pins; use `powershell-pin-audit` for that. Do not copy the PowerShell source tree to `master`: it remains a `pwsh-src` submodule pinned to a commit on a per-release downstream branch.
+
+Keep source checkout and build metadata separate:
+
+- `POWERSHELL_RELEASE_TAG` is the upstream release tag, `vX.Y.Z`.
+- `POWERSHELL_UPSTREAM_TAG` is the mirrored tag, `upstream/vX.Y.Z`.
+- `POWERSHELL_SOURCE_REF` is the patched source branch, `downstream/vX.Y.Z`.
 
 ## Prerequisites
 
 - PowerShell 7 (`pwsh`).
-- The upstream release tag should already be mirrored as `upstream/vX.Y.Z`.
-- The downstream patch branch should exist as `downstream/vX.Y.Z`.
-- Initialize `pwsh-src/` when you want the script to discover the target framework automatically.
+- Git push permission for this repository. The source branch and mirrored upstream tag must be available on `origin` before `master` points at them.
+- A clean or understood working tree. Do not overwrite unrelated work.
+- Yayaml for workflow parsing:
+
+  ```powershell
+  Install-Module Yayaml -Scope CurrentUser
+  ```
 
 ## Scripts
 
 - `scripts\Set-PowerShellReleasePins.ps1`: Updates text pins in both PowerShell workflows, `.gitmodules`, and README.
-- `..\\powershell-pin-audit\\scripts\\Test-PowerShellPins.ps1`: Audits the resulting pins after the edit.
-- `..\\..\\..\\..\\scripts\\New-PowerShellPatchBranch.ps1`: Creates a downstream branch from a mirrored upstream tag when needed.
-- `..\\..\\..\\..\\scripts\\Sync-PowerShellUpstream.ps1`: Syncs upstream refs and mirrored upstream tags.
+- `..\powershell-pin-audit\scripts\Test-PowerShellPins.ps1`: Audits the resulting pins after the edit.
+- `..\..\..\..\scripts\New-PowerShellPatchBranch.ps1`: Creates `downstream/vX.Y.Z` from `upstream/vX.Y.Z`.
+- `..\..\..\..\scripts\Sync-PowerShellUpstream.ps1`: Mirrors upstream refs and namespaced tags.
+- `..\..\..\..\scripts\Build-LocalPowerShellSdk.ps1`: Canonical local SDK build. Prefer the `powershell-sdk-package-validate` skill to run it with package validation.
 
-## Usage
+## Upgrade procedure
 
-Create a downstream patch branch if it does not already exist:
+Set the previous and target PowerShell releases. The examples below update `7.6.4` to `7.6.5`.
+
+```powershell
+$PreviousVersion = '7.6.4'
+$Version = '7.6.5'
+```
+
+### 1. Inspect the release and existing patch series
+
+Confirm that the upstream release exists, identify every downstream commit in oldest-first order, and record the current target framework:
+
+```powershell
+gh api "repos/PowerShell/PowerShell/releases/tags/v$Version" --jq '.tag_name, .published_at, .target_commitish'
+git log --oneline --reverse "upstream/v$PreviousVersion..downstream/v$PreviousVersion"
+git show "upstream/v$PreviousVersion:PowerShell.Common.props" |
+  Select-String -Pattern 'TargetFramework'
+```
+
+The patch range is the source of truth. Carry all of its commits unless a newer upstream release has already incorporated an equivalent change.
+
+### 2. Mirror and publish the upstream release tag
+
+Synchronize namespaced upstream tags, verify the target tag, and publish only that new mirror tag:
 
 ```powershell
 pwsh .\scripts\Sync-PowerShellUpstream.ps1 -SyncTags
-pwsh .\scripts\New-PowerShellPatchBranch.ps1 -Version 7.6.4
+git rev-parse --verify "upstream/v$Version^{commit}"
+git show "upstream/v$Version:PowerShell.Common.props" |
+  Select-String -Pattern 'TargetFramework'
+git push origin "refs/tags/upstream/v$Version:refs/tags/upstream/v$Version"
 ```
 
-Update the repository text pins, deriving the target framework from `pwsh-src\PowerShell.Common.props`:
+Use the target release's `PowerShell.Common.props` as the target-framework authority. It may change between PowerShell releases; never hardcode an assumed `net*` folder.
+
+### 3. Create and patch the downstream source branch
+
+Create the downstream branch from the mirrored tag, then use an isolated linked worktree for source changes. Keep this worktree outside the repository checkout or in ignored `pwsh-src-worktree\`; never commit it to `master`.
 
 ```powershell
-pwsh .\.agents\skills\powershell-release-bump\scripts\Set-PowerShellReleasePins.ps1 -Version 7.6.4
+pwsh .\scripts\New-PowerShellPatchBranch.ps1 -Version $Version
+$PatchWorktree = Join-Path $env:TEMP "pwsh-src-v$Version"
+git worktree add $PatchWorktree "downstream/v$Version"
+
+$PatchCommits = git rev-list --reverse "upstream/v$PreviousVersion..downstream/v$PreviousVersion"
+foreach ($PatchCommit in $PatchCommits) {
+  git -C $PatchWorktree cherry-pick $PatchCommit
+  if ($LASTEXITCODE -ne 0) {
+    throw "Resolve the cherry-pick for $PatchCommit in $PatchWorktree before continuing."
+  }
+}
 ```
 
-If the submodule is not initialized yet, pass the framework explicitly:
+When a cherry-pick conflicts, inspect the target release's implementation and port the downstream intent, then continue:
 
 ```powershell
-pwsh .\.agents\skills\powershell-release-bump\scripts\Set-PowerShellReleasePins.ps1 -Version 7.6.4 -TargetFramework net10.0
+git -C $PatchWorktree status
+# Resolve only the relevant source conflict, then:
+git -C $PatchWorktree add <resolved-files>
+git -C $PatchWorktree cherry-pick --continue
 ```
 
-Preview the text edits:
+If Git reports an empty cherry-pick, first verify the target release already contains the downstream behavior. Only then skip it:
 
 ```powershell
-pwsh .\.agents\skills\powershell-release-bump\scripts\Set-PowerShellReleasePins.ps1 -Version 7.6.4 -TargetFramework net10.0 -WhatIf
+git -C $PatchWorktree show --stat CHERRY_PICK_HEAD
+git -C $PatchWorktree cherry-pick --skip
 ```
 
-Then bump the pinned source submodule commit on `master`:
+Validate the patched source, confirm it remains based on the target upstream tag, then publish the branch before updating the submodule:
+
+```powershell
+git -C $PatchWorktree diff --check
+git -C $PatchWorktree merge-base --is-ancestor "upstream/v$Version^{commit}" HEAD
+git -C $PatchWorktree log --oneline "upstream/v$Version..HEAD"
+git push origin "downstream/v$Version"
+```
+
+### 4. Update coordinated distribution pins
+
+Read the target framework from the patched worktree and pass it to the pin script. Passing it explicitly avoids depending on the currently pinned `pwsh-src` checkout, which still represents the previous release.
+
+```powershell
+[xml] $CommonProps = Get-Content -Raw (Join-Path $PatchWorktree 'PowerShell.Common.props')
+$TargetFramework = $CommonProps.Project.PropertyGroup |
+  ForEach-Object { $_.TargetFramework } |
+  Where-Object { $_ } |
+  Select-Object -First 1
+
+pwsh .\.agents\skills\powershell-release-bump\scripts\Set-PowerShellReleasePins.ps1 `
+  -Version $Version `
+  -TargetFramework $TargetFramework
+```
+
+The script updates these coordinated surfaces:
+
+- `POWERSHELL_VERSION`, `POWERSHELL_RELEASE_TAG`, `POWERSHELL_UPSTREAM_TAG`, and `POWERSHELL_SOURCE_REF` in both PowerShell workflows.
+- The CLI's `SDK_PACKAGE_VERSION`, retaining the selected numeric `SDK_PACKAGE_REVISION`.
+- The literal `branch = downstream/vX.Y.Z` line in `.gitmodules`.
+- The README "Current pins" upstream release, source ref, target framework, and SDK workflow-default version.
+
+Update the gitlink only after the new downstream branch is on `origin`:
 
 ```powershell
 git submodule update --remote pwsh-src
 git add pwsh-src
 ```
 
-Finish by auditing pins and checking the diff:
+### 5. Validate and clean up
+
+The checked-out submodule is now the target-framework authority for the final audit:
 
 ```powershell
 pwsh .\.agents\skills\powershell-pin-audit\scripts\Test-PowerShellPins.ps1 -RequireSubmodule
+
+Import-Module Yayaml
+Get-Content -Raw .github\workflows\powershell-sdk.yml | ConvertFrom-Yaml | Out-Null
+Get-Content -Raw .github\workflows\powershell-cli.yml | ConvertFrom-Yaml | Out-Null
+
+git -C pwsh-src rev-parse --verify "upstream/v$Version^{commit}"
+git -C pwsh-src merge-base --is-ancestor "upstream/v$Version^{commit}" HEAD
 git --no-pager diff --check
+git --no-pager diff --cached --check
+git submodule status pwsh-src
+git status --short
 ```
 
-## Review checklist
+Remove the temporary worktree only after it is clean:
 
-1. Confirm both workflows use the same `POWERSHELL_VERSION`, `POWERSHELL_RELEASE_TAG`, `POWERSHELL_UPSTREAM_TAG`, and `POWERSHELL_SOURCE_REF`.
-2. Confirm `.gitmodules` has a literal `branch = downstream/vX.Y.Z` value.
-3. Confirm README current pins match the workflow values and upstream target framework.
-4. Confirm `pwsh-src` is a submodule pointer change, not a copied PowerShell source tree.
-5. Confirm generated output directories such as `output\`, `package\`, `dotnet-runtime\`, and `pwsh-src-worktree\` are not staged.
+```powershell
+git worktree remove $PatchWorktree
+git worktree prune
+```
+
+Before opening the distribution PR, use `powershell-sdk-package-validate` to build and validate one local SDK package. In GitHub Actions, run the SDK workflow before the CLI distribution workflow.
+
+## Safety checklist
+
+1. Verify both workflows agree on all four `POWERSHELL_*` release pins.
+2. Verify `POWERSHELL_RELEASE_TAG` remains `vX.Y.Z`, not `downstream/vX.Y.Z`.
+3. Confirm the current `pwsh-src` commit is a descendant of `upstream/vX.Y.Z` and is on the published `downstream/vX.Y.Z` branch.
+4. Confirm `.gitmodules` has a literal `branch = downstream/vX.Y.Z` value and the submodule diff is a gitlink update, not copied source files.
+5. Ensure no generated `output\`, `package\`, archive, `dotnet-runtime\`, or temporary source-worktree paths are staged.
+6. Do not create a downstream release tag until validated artifacts are ready; downstream tags use `vX.Y.Z.R`, never plain `vX.Y.Z`.

--- a/.github/workflows/powershell-cli.yml
+++ b/.github/workflows/powershell-cli.yml
@@ -64,13 +64,13 @@ permissions:
   actions: read
   contents: read
 env:
-  POWERSHELL_VERSION: "7.6.4"
-  POWERSHELL_RELEASE_TAG: "v7.6.4"
-  POWERSHELL_UPSTREAM_TAG: "upstream/v7.6.4"
+  POWERSHELL_VERSION: "7.6.5"
+  POWERSHELL_RELEASE_TAG: "v7.6.5"
+  POWERSHELL_UPSTREAM_TAG: "upstream/v7.6.5"
   POWERSHELL_SOURCE_REPOSITORY: ${{ github.repository }}
-  POWERSHELL_SOURCE_REF: "downstream/v7.6.4"
+  POWERSHELL_SOURCE_REF: "downstream/v7.6.5"
   SDK_PACKAGE_ID: "Devolutions.PowerShell.SDK"
-  SDK_PACKAGE_VERSION: "7.6.4.0"
+  SDK_PACKAGE_VERSION: "7.6.5.0"
   SDK_PACKAGE_REVISION: "0"
   SDK_PACKAGE_SOURCE: "https://api.nuget.org/v3/index.json"
 jobs:

--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -106,11 +106,11 @@ permissions:
   contents: read
 
 env:
-  POWERSHELL_VERSION: "7.6.4"
-  POWERSHELL_RELEASE_TAG: "v7.6.4"
-  POWERSHELL_UPSTREAM_TAG: "upstream/v7.6.4"
+  POWERSHELL_VERSION: "7.6.5"
+  POWERSHELL_RELEASE_TAG: "v7.6.5"
+  POWERSHELL_UPSTREAM_TAG: "upstream/v7.6.5"
   POWERSHELL_SOURCE_REPOSITORY: ${{ github.repository }}
-  POWERSHELL_SOURCE_REF: "downstream/v7.6.4"
+  POWERSHELL_SOURCE_REF: "downstream/v7.6.5"
   POWERSHELL_VENDOR_NAME: "Devolutions"
   SDK_VENDOR_NAME: "Devolutions"
   SDK_PACKAGE_ID: "Devolutions.PowerShell.SDK"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "pwsh-src"]
 	path = pwsh-src
 	url = ./
-	branch = downstream/v7.6.4
+	branch = downstream/v7.6.5

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ The local script writes under `output\local-sdk\<rid>\` and produces a single-RI
 
 | Component | Version |
 | --- | --- |
-| PowerShell upstream release | `7.6.4` / `v7.6.4` |
-| PowerShell downstream source ref | `downstream/v7.6.4` based on `upstream/v7.6.4` |
+| PowerShell upstream release | `7.6.5` / `v7.6.5` |
+| PowerShell downstream source ref | `downstream/v7.6.5` based on `upstream/v7.6.5` |
 | PowerShell target framework | `net10.0` |
-| PowerShell SDK package | `Devolutions.PowerShell.SDK` / `7.6.4.0` workflow default; `7.6.3.2` latest published package |
+| PowerShell SDK package | `Devolutions.PowerShell.SDK` / `7.6.5.0` workflow default; `7.6.3.2` latest published package |
 | Latest downstream release tag | `v7.6.3.2` |
 | Latest PowerShell CLI release assets | `PowerShell-7.6.3-<os>-<arch>.tar.gz` for Windows, macOS, and Linux on x64 and arm64 |
 | PowerShell SDK package source | `https://api.nuget.org/v3/index.json` |


### PR DESCRIPTION
## Summary
- update workflow, submodule, and README pins to PowerShell 7.6.5
- pin `pwsh-src` to the published `downstream/v7.6.5` patch branch
- document the complete upstream-mirroring, patch-porting, and validation workflow in the release-bump skill

## Validation
- PowerShell pin audit with the initialized submodule
- Yayaml parsing for both PowerShell workflows
- source ancestry and git diff checks