### PR TITLE
Fix SDK bootstrap on macOS ARM64

### DIFF
--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -413,7 +413,18 @@ jobs:
           $ErrorActionPreference = 'Stop'
           Import-Module .\build.psm1 -Force
           Import-Module (Join-Path $PWD '../eng/PowerShellSdkPackaging.psm1') -Force
-          Start-PSBootstrap -Scenario DotNet
+          # The workflow already installs the SDK; prevent bootstrap from installing the unused dotnet-format global tool.
+          $PreviousTfBuild = $env:TF_BUILD
+          try {
+            $env:TF_BUILD = 'true'
+            Start-PSBootstrap -Scenario DotNet
+          } finally {
+            if ($null -eq $PreviousTfBuild) {
+              Remove-Item Env:\TF_BUILD -ErrorAction SilentlyContinue
+            } else {
+              $env:TF_BUILD = $PreviousTfBuild
+            }
+          }
 
           if ($IsWindows) {
             Switch-PSNugetConfig -Source Public
@@ -869,7 +880,18 @@ jobs:
           Import-Module .\build.psm1 -Force
           Import-Module (Join-Path $PWD '../eng/PowerShellSdkPackaging.psm1') -Force
           $env:PowerShellVendor = $Env:POWERSHELL_VENDOR_NAME
-          Start-PSBootstrap -Scenario DotNet
+          # The workflow already installs the SDK; prevent bootstrap from installing the unused dotnet-format global tool.
+          $PreviousTfBuild = $env:TF_BUILD
+          try {
+            $env:TF_BUILD = 'true'
+            Start-PSBootstrap -Scenario DotNet
+          } finally {
+            if ($null -eq $PreviousTfBuild) {
+              Remove-Item Env:\TF_BUILD -ErrorAction SilentlyContinue
+            } else {
+              $env:TF_BUILD = $PreviousTfBuild
+            }
+          }
           Start-PSBuild -Clean -PSModuleRestore -Configuration Release -ReleaseTag $Env:POWERSHELL_RELEASE_TAG -UseNuGetOrg
 
           [xml]$CommonProps = Get-Content ./PowerShell.Common.props

--- a/scripts/Build-LocalPowerShellSdk.ps1
+++ b/scripts/Build-LocalPowerShellSdk.ps1
@@ -452,7 +452,18 @@ $OriginalModuleNugetConfig = if ($HadModuleNugetConfig) { Get-Content -LiteralPa
 Push-Location $PwshSourceRoot
 try {
   Import-Module .\build.psm1 -Force
-  Start-PSBootstrap -Scenario DotNet
+  # The SDK is installed by the caller; prevent bootstrap from installing the unused dotnet-format global tool.
+  $PreviousTfBuild = $env:TF_BUILD
+  try {
+    $env:TF_BUILD = 'true'
+    Start-PSBootstrap -Scenario DotNet
+  } finally {
+    if ($null -eq $PreviousTfBuild) {
+      Remove-Item Env:\TF_BUILD -ErrorAction SilentlyContinue
+    } else {
+      $env:TF_BUILD = $PreviousTfBuild
+    }
+  }
   if ($IsWindows) {
     Switch-PSNugetConfig -Source Public
     $ModuleNugetConfig = @(

--- a/scripts/Build-LocalPowerShellSdk.ps1
+++ b/scripts/Build-LocalPowerShellSdk.ps1
@@ -452,7 +452,7 @@ $OriginalModuleNugetConfig = if ($HadModuleNugetConfig) { Get-Content -LiteralPa
 Push-Location $PwshSourceRoot
 try {
   Import-Module .\build.psm1 -Force
-  # The SDK is installed by the caller; prevent bootstrap from installing the unused dotnet-format global tool.
+  # Packaging does not use dotnet-format; prevent bootstrap from installing that global tool.
   $PreviousTfBuild = $env:TF_BUILD
   try {
     $env:TF_BUILD = 'true'


### PR DESCRIPTION
## Summary
- prevent PowerShell bootstrap from installing the unused `dotnet-format` global tool in CI
- retain bootstrap dependency checks and restore the original environment afterward
- keep the canonical local SDK build aligned with the workflow

## Root cause
The macOS ARM64 release job repeatedly failed when `Start-PSBootstrap -Scenario DotNet` invoked `dotnet tool install --global dotnet-format`, which crashed with a .NET `NullReferenceException`.