### PR TITLE
Handle SDK releases without localized resources

### DIFF
--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -1130,12 +1130,9 @@ jobs:
           }
           foreach ($RuntimeGroup in $LocalizedResourceSources.Keys) {
             $LocalizedResourceDestinationRoot = Join-Path $SdkStagePath "buildTransitive/localized-resources/$RuntimeGroup/lib/$TargetFramework"
-            $CopiedLocalizedResourceCount = Copy-LocalizedResourcesToPackage `
+            Copy-LocalizedResourcesToPackage `
               -SourceRoot $LocalizedResourceSources[$RuntimeGroup] `
-              -DestinationRoot $LocalizedResourceDestinationRoot
-            if ($CopiedLocalizedResourceCount -eq 0) {
-              throw "No localized resources were staged for runtime group '$RuntimeGroup' from $($LocalizedResourceSources[$RuntimeGroup])"
-            }
+              -DestinationRoot $LocalizedResourceDestinationRoot | Out-Null
           }
 
           $WindowsDesktopPayloadSourceRoot = Join-Path $AppHostDownloadPath 'PowerShell-SDK-AppHost-win-x64/windows-desktop-payload'

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Use `PowerShellSDKCopyPhases` to decide where opted-in payloads are copied. The 
 | `PowerShellSDKConfig` | `Copy` | `None`, `Copy` | Generates `powershell.config.json` when an apphost layout is enabled. |
 | `PowerShellSDKConfigExecutionPolicy` | `Bypass` | PowerShell execution policy | Sets `Microsoft.PowerShell:ExecutionPolicy` in generated config. |
 | `PowerShellSDKConfigOverwriteExisting` | `false` | `true`, `false` | Replaces existing `powershell.config.json` only when `true`. |
-| `PowerShellSDKLocalizedResources` | `None` | `None`, `Copy` | Copies staged localized resource assemblies beside the apphost payload. |
+| `PowerShellSDKLocalizedResources` | `None` | `None`, `Copy` | Copies staged localized resource assemblies beside the apphost payload when the source package includes them. |
 | `PowerShellSDKPSGalleryModules` | `None` | `None`, `All`, or module list | Copies all staged PSGallery modules or a semicolon-delimited subset to `Modules`. |
 
 When passing semicolon-delimited values on the `dotnet` or `msbuild` command line, encode semicolons as `%3B`, such as `/p:PowerShellSDKCopyPhases=Output%3BPublish`.

--- a/eng/Microsoft.PowerShell.SDK.targets
+++ b/eng/Microsoft.PowerShell.SDK.targets
@@ -454,11 +454,10 @@
           DependsOnTargets="_PowerShellSDKResolveAppHost"
           AfterTargets="PowerShellSDKCopyAppHostToOutput"
           Condition="'$(_PowerShellSDKLocalizedResourcesCopyToOutputEnabled)' == 'true' and '$(_PowerShellSDKRootAppHostEnabled)' == 'true'">
-    <Error Condition="'@(_PowerShellSDKAppHostLocalizedResourceFile)' == ''"
-           Text="PowerShellSDKLocalizedResources=Copy, but this PowerShell SDK package does not include localized resources for runtime group '$(_PowerShellSDKAppHostRuntimeGroup)' and target framework '$(TargetFramework)'." />
     <Copy SourceFiles="@(_PowerShellSDKAppHostLocalizedResourceFile)"
           DestinationFiles="@(_PowerShellSDKAppHostLocalizedResourceFile->'$(OutDir)%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true" />
+          SkipUnchangedFiles="true"
+          Condition="'@(_PowerShellSDKAppHostLocalizedResourceFile)' != ''" />
   </Target>
 
   <Target Name="PowerShellSDKCopyRuntimeNativeAppHostsToOutput"
@@ -521,11 +520,10 @@
           DependsOnTargets="_PowerShellSDKResolveRuntimeNativeAppHosts"
           AfterTargets="PowerShellSDKCopyRuntimeNativeAppHostsToOutput"
           Condition="'$(_PowerShellSDKLocalizedResourcesCopyToOutputEnabled)' == 'true' and '$(_PowerShellSDKRuntimeNativeAppHostEnabled)' == 'true'">
-    <Error Condition="'@(_PowerShellSDKRuntimeNativeSharedLocalizedResourceFile)' == ''"
-           Text="PowerShellSDKLocalizedResources=Copy, but this PowerShell SDK package does not include localized resources for runtime group '$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)' and target framework '$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)'." />
     <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeSharedLocalizedResourceFile)"
           DestinationFiles="@(_PowerShellSDKRuntimeNativeSharedLocalizedResourceFile->'$(OutDir)%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true" />
+          SkipUnchangedFiles="true"
+          Condition="'@(_PowerShellSDKRuntimeNativeSharedLocalizedResourceFile)' != ''" />
   </Target>
 
   <Target Name="PowerShellSDKCopyPSGalleryModulesToOutput"
@@ -585,11 +583,10 @@
           DependsOnTargets="_PowerShellSDKResolveAppHost"
           AfterTargets="Publish"
           Condition="'$(_PowerShellSDKLocalizedResourcesCopyToPublishEnabled)' == 'true' and '$(_PowerShellSDKRootAppHostEnabled)' == 'true'">
-    <Error Condition="'@(_PowerShellSDKAppHostLocalizedResourceFile)' == ''"
-           Text="PowerShellSDKLocalizedResources=Copy, but this PowerShell SDK package does not include localized resources for runtime group '$(_PowerShellSDKAppHostRuntimeGroup)' and target framework '$(TargetFramework)'." />
     <Copy SourceFiles="@(_PowerShellSDKAppHostLocalizedResourceFile)"
           DestinationFiles="@(_PowerShellSDKAppHostLocalizedResourceFile->'$(PublishDir)%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true" />
+          SkipUnchangedFiles="true"
+          Condition="'@(_PowerShellSDKAppHostLocalizedResourceFile)' != ''" />
   </Target>
 
   <Target Name="PowerShellSDKAddRuntimeNativeAppHostsToPublish"
@@ -646,11 +643,10 @@
           DependsOnTargets="_PowerShellSDKResolveRuntimeNativeAppHosts"
           AfterTargets="Publish"
           Condition="'$(_PowerShellSDKLocalizedResourcesCopyToPublishEnabled)' == 'true' and '$(_PowerShellSDKRuntimeNativeCopyToPublishEnabled)' == 'true'">
-    <Error Condition="'@(_PowerShellSDKRuntimeNativeSharedLocalizedResourceFile)' == ''"
-           Text="PowerShellSDKLocalizedResources=Copy, but this PowerShell SDK package does not include localized resources for runtime group '$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)' and target framework '$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)'." />
     <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeSharedLocalizedResourceFile)"
           DestinationFiles="@(_PowerShellSDKRuntimeNativeSharedLocalizedResourceFile->'$(PublishDir)%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true" />
+          SkipUnchangedFiles="true"
+          Condition="'@(_PowerShellSDKRuntimeNativeSharedLocalizedResourceFile)' != ''" />
   </Target>
 
   <Target Name="PowerShellSDKAddPSGalleryModulesToPublish"

--- a/eng/Validate-PowerShellSdkPackage.ps1
+++ b/eng/Validate-PowerShellSdkPackage.ps1
@@ -658,6 +658,40 @@ function Assert-LocalizedResourcePresent {
   }
 }
 
+function Get-LocalizedResourceFileSnapshot {
+  param(
+    [Parameter(Mandatory)]
+    [string] $Directory
+  )
+
+  return @(
+    Get-ChildItem -LiteralPath $Directory -Recurse -File -Filter '*.resources.dll' |
+      Sort-Object FullName |
+      ForEach-Object {
+        $RelativePath = $_.FullName.Substring($Directory.Length).TrimStart([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+        "$RelativePath|$((Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash)"
+      }
+  )
+}
+
+function Assert-LocalizedResourceFilesUnchanged {
+  param(
+    [Parameter(Mandatory)]
+    [string[]] $ExpectedSnapshot,
+
+    [Parameter(Mandatory)]
+    [string[]] $ActualSnapshot,
+
+    [Parameter(Mandatory)]
+    [string] $Description
+  )
+
+  $Difference = @(Compare-Object -ReferenceObject $ExpectedSnapshot -DifferenceObject $ActualSnapshot)
+  if ($Difference.Count -ne 0) {
+    throw "$Description changed localized resource files: $($Difference.InputObject -join ', ')"
+  }
+}
+
 function Invoke-RuntimeNativeOverwriteProbe {
   param(
     [Parameter(Mandatory)]
@@ -937,10 +971,10 @@ function Invoke-AppHostLayoutMatrixProbe {
   )
 
   $Layouts = @(
-    [pscustomobject]@{ Name = 'None'; AppHostLayout = ''; ExpectRootAppHost = $false; ExpectRuntimeNativeAppHost = $false; CopyPSGalleryModules = $false },
-    [pscustomobject]@{ Name = 'Root'; AppHostLayout = 'Root'; ExpectRootAppHost = $true; ExpectRuntimeNativeAppHost = $false; CopyPSGalleryModules = $false },
-    [pscustomobject]@{ Name = 'RuntimeNative'; AppHostLayout = 'RuntimeNative'; ExpectRootAppHost = $false; ExpectRuntimeNativeAppHost = $true; CopyPSGalleryModules = $true },
-    [pscustomobject]@{ Name = 'Both'; AppHostLayout = 'Both'; ExpectRootAppHost = $true; ExpectRuntimeNativeAppHost = $true; CopyPSGalleryModules = $true }
+    [pscustomobject]@{ Name = 'None'; AppHostLayout = ''; ExpectRootAppHost = $false; ExpectRuntimeNativeAppHost = $false; CopyPSGalleryModules = $false; CopyLocalizedResources = $false },
+    [pscustomobject]@{ Name = 'Root'; AppHostLayout = 'Root'; ExpectRootAppHost = $true; ExpectRuntimeNativeAppHost = $false; CopyPSGalleryModules = $false; CopyLocalizedResources = $true },
+    [pscustomobject]@{ Name = 'RuntimeNative'; AppHostLayout = 'RuntimeNative'; ExpectRootAppHost = $false; ExpectRuntimeNativeAppHost = $true; CopyPSGalleryModules = $true; CopyLocalizedResources = $false },
+    [pscustomobject]@{ Name = 'Both'; AppHostLayout = 'Both'; ExpectRootAppHost = $true; ExpectRuntimeNativeAppHost = $true; CopyPSGalleryModules = $true; CopyLocalizedResources = $false }
   )
 
   foreach ($Layout in $Layouts) {
@@ -1063,6 +1097,19 @@ if (ps.HadErrors)
       if ($Layout.CopyPSGalleryModules) {
         Assert-PSGalleryModulesPresent -Directory $ProbeOutputDirectory -ModuleNames $PSGalleryProbeModuleNames -Description $Description
       }
+      if ($Layout.CopyLocalizedResources) {
+        $LocalizedResourceOutputBefore = @(Get-LocalizedResourceFileSnapshot -Directory $ProbeOutputDirectory)
+        Invoke-DotNet @(
+          'msbuild',
+          $ProjectPath,
+          '-nologo',
+          '-verbosity:minimal',
+          '-t:PowerShellSDKCopyAppHostLocalizedResourcesToOutput',
+          '/p:PowerShellSDKLocalizedResources=Copy'
+        )
+        $LocalizedResourceOutputAfter = @(Get-LocalizedResourceFileSnapshot -Directory $ProbeOutputDirectory)
+        Assert-LocalizedResourceFilesUnchanged -ExpectedSnapshot $LocalizedResourceOutputBefore -ActualSnapshot $LocalizedResourceOutputAfter -Description "$Description localized resources output opt-in"
+      }
       if ($Layout.ExpectRootAppHost) {
         Assert-AppHostOutput -Directory $ProbeOutputDirectory -ExecutableName $ExecutableName -Description $Description
         if (-not $SkipRuntimeExecution) {
@@ -1080,6 +1127,46 @@ if (ps.HadErrors)
             Invoke-PwshModuleProbe -PwshPath $RuntimeNativePwshPath -ModuleRoot (Join-Path $ProbeOutputDirectory 'Modules')
           }
         }
+      }
+
+      if ($Layout.CopyLocalizedResources) {
+        $LocalizedPublishDirectory = Join-Path $ProbeDirectory (Join-Path 'bin' (Join-Path 'Release' (Join-Path $SampleTargetFramework (Join-Path $CurrentRuntimeIdentifier 'publish-localized'))))
+        Remove-Item -LiteralPath $LocalizedPublishDirectory -Recurse -Force -ErrorAction SilentlyContinue
+        Invoke-DotNet @(
+          'publish',
+          $ProjectPath,
+          '--nologo',
+          '--verbosity',
+          'minimal',
+          '-c',
+          'Release',
+          '-r',
+          $CurrentRuntimeIdentifier,
+          '--self-contained',
+          'false',
+          '-o',
+          $LocalizedPublishDirectory
+        )
+        $LocalizedResourcePublishBefore = @(Get-LocalizedResourceFileSnapshot -Directory $LocalizedPublishDirectory)
+        Invoke-DotNet @(
+          'publish',
+          $ProjectPath,
+          '--nologo',
+          '--verbosity',
+          'minimal',
+          '-c',
+          'Release',
+          '-r',
+          $CurrentRuntimeIdentifier,
+          '--self-contained',
+          'false',
+          '-o',
+          $LocalizedPublishDirectory,
+          '/p:PowerShellSDKLocalizedResources=Copy'
+        )
+        $LocalizedResourcePublishAfter = @(Get-LocalizedResourceFileSnapshot -Directory $LocalizedPublishDirectory)
+        Assert-AppHostOutput -Directory $LocalizedPublishDirectory -ExecutableName $ExecutableName -Description "$($Layout.Name) layout localized resource publish output"
+        Assert-LocalizedResourceFilesUnchanged -ExpectedSnapshot $LocalizedResourcePublishBefore -ActualSnapshot $LocalizedResourcePublishAfter -Description "$($Layout.Name) layout localized resource publish opt-in"
       }
 
       $ProbeOutput = & dotnet run --project $ProjectPath --no-build

--- a/eng/Validate-PowerShellSdkPackage.ps1
+++ b/eng/Validate-PowerShellSdkPackage.ps1
@@ -609,14 +609,14 @@ function Get-RepresentativeLocalizedResourcePath {
 
   $LocalizedResourceRoot = Join-Path $RestoredSdkPath "buildTransitive/localized-resources/$RuntimeAssetGroup/lib/$TargetFramework"
   if (-not (Test-Path $LocalizedResourceRoot -PathType Container)) {
-    throw "Restored SDK package is missing localized resource root: $LocalizedResourceRoot"
+    return $null
   }
 
   $LocalizedResourceFile = Get-ChildItem -LiteralPath $LocalizedResourceRoot -Recurse -File -Filter '*.resources.dll' |
     Sort-Object FullName |
     Select-Object -First 1
   if (-not $LocalizedResourceFile) {
-    throw "Restored SDK package contains no localized resource files under: $LocalizedResourceRoot"
+    return $null
   }
 
   return $LocalizedResourceFile.FullName.Substring($LocalizedResourceRoot.Length + 1)
@@ -1677,7 +1677,12 @@ foreach (PSObject result in ps.Invoke())
   }
   $FrameworkDependentAppHostSelfContained = Test-RuntimeConfigSelfContained -RuntimeConfigPath (Join-Path $RestoredSdkPath "tools/apphost/$RuntimeIdentifier/pwsh.runtimeconfig.json")
   $RepresentativeLocalizedResourcePath = Get-RepresentativeLocalizedResourcePath -RestoredSdkPath $RestoredSdkPath -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework
-  $RepresentativeLocalizedResourcePackagePath = Join-Path $RestoredSdkPath "buildTransitive/localized-resources/$RuntimeAssetGroup/lib/$TargetFramework/$RepresentativeLocalizedResourcePath"
+  $RepresentativeLocalizedResourcePackagePath = $null
+  if ($RepresentativeLocalizedResourcePath) {
+    $RepresentativeLocalizedResourcePackagePath = Join-Path $RestoredSdkPath "buildTransitive/localized-resources/$RuntimeAssetGroup/lib/$TargetFramework/$RepresentativeLocalizedResourcePath"
+  } else {
+    Write-Host "SDK package does not include localized resources for '$RuntimeAssetGroup/$TargetFramework'; validating PowerShellSDKLocalizedResources=Copy as a no-op."
+  }
 
   Invoke-DotNet @('build', $ProjectPath, '--no-restore', '--nologo', '--verbosity', 'minimal')
 
@@ -1730,9 +1735,11 @@ foreach (PSObject result in ps.Invoke())
   )
   Assert-PowerShellConfig -Directory $OutputDirectory -ExpectedExecutionPolicy 'Bypass' -Description 'Sample app output restored config'
 
-  $OutputLocalizedResourcePath = Join-Path $OutputDirectory $RepresentativeLocalizedResourcePath
-  Remove-Item -LiteralPath $OutputLocalizedResourcePath -Force -ErrorAction SilentlyContinue
-  Assert-LocalizedResourceAbsent -Directory $OutputDirectory -RelativePath $RepresentativeLocalizedResourcePath -Description 'Sample app output before localized resources opt-in'
+  if ($RepresentativeLocalizedResourcePath) {
+    $OutputLocalizedResourcePath = Join-Path $OutputDirectory $RepresentativeLocalizedResourcePath
+    Remove-Item -LiteralPath $OutputLocalizedResourcePath -Force -ErrorAction SilentlyContinue
+    Assert-LocalizedResourceAbsent -Directory $OutputDirectory -RelativePath $RepresentativeLocalizedResourcePath -Description 'Sample app output before localized resources opt-in'
+  }
   Invoke-DotNet @(
     'msbuild',
     $ProjectPath,
@@ -1741,8 +1748,10 @@ foreach (PSObject result in ps.Invoke())
     '-t:PowerShellSDKCopyRuntimeNativeLocalizedResourcesToOutput',
     '/p:PowerShellSDKLocalizedResources=Copy'
   )
-  Assert-LocalizedResourcePresent -Directory $OutputDirectory -RelativePath $RepresentativeLocalizedResourcePath -Description 'Sample app output with localized resources opt-in'
-  Assert-FileContentMatches -ExpectedPath $RepresentativeLocalizedResourcePackagePath -ActualPath $OutputLocalizedResourcePath -Description 'Sample app output localized resource opt-in'
+  if ($RepresentativeLocalizedResourcePath) {
+    Assert-LocalizedResourcePresent -Directory $OutputDirectory -RelativePath $RepresentativeLocalizedResourcePath -Description 'Sample app output with localized resources opt-in'
+    Assert-FileContentMatches -ExpectedPath $RepresentativeLocalizedResourcePackagePath -ActualPath $OutputLocalizedResourcePath -Description 'Sample app output localized resource opt-in'
+  }
 
   if (-not $SkipRuntimeExecution) {
     $AppOutput = & dotnet run --project $ProjectPath --no-build
@@ -1869,8 +1878,10 @@ foreach (PSObject result in ps.Invoke())
     '/p:PowerShellSDKLocalizedResources=Copy'
   )
   Assert-SharedPowerShellOutput -Directory $LocalizedPublishDirectory -SelfContained $FrameworkDependentAppHostSelfContained -Description 'Sample localized resource publish output'
-  Assert-LocalizedResourcePresent -Directory $LocalizedPublishDirectory -RelativePath $RepresentativeLocalizedResourcePath -Description 'Sample localized resource publish output'
-  Assert-FileContentMatches -ExpectedPath $RepresentativeLocalizedResourcePackagePath -ActualPath (Join-Path $LocalizedPublishDirectory $RepresentativeLocalizedResourcePath) -Description 'Sample localized resource publish output'
+  if ($RepresentativeLocalizedResourcePath) {
+    Assert-LocalizedResourcePresent -Directory $LocalizedPublishDirectory -RelativePath $RepresentativeLocalizedResourcePath -Description 'Sample localized resource publish output'
+    Assert-FileContentMatches -ExpectedPath $RepresentativeLocalizedResourcePackagePath -ActualPath (Join-Path $LocalizedPublishDirectory $RepresentativeLocalizedResourcePath) -Description 'Sample localized resource publish output'
+  }
 
   Write-Host "Validated $PackageId $PackageVersion from $($Package.FullName)"
   if ($SkipRuntimeExecution) {


### PR DESCRIPTION
PowerShell 7.6.5 no longer emits the satellite assemblies that the SDK workflow previously required, causing package assembly to fail despite a successful source build.

Treat localized resources as optional payloads throughout SDK assembly and consumption. `PowerShellSDKLocalizedResources=Copy` now remains a no-op when a source package has none, while validation covers both populated and empty-resource packages.