### PR TITLE
Add PowerShellSDKXmlDocumentation import option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ To also copy a runnable PowerShell apphost beside your app, opt in from the proj
 <PropertyGroup>
   <PowerShellSDKAppHostLayout>Root</PowerShellSDKAppHostLayout>
   <PowerShellSDKLocalizedResources>Copy</PowerShellSDKLocalizedResources>
+  <PowerShellSDKXmlDocumentation>Copy</PowerShellSDKXmlDocumentation>
   <PowerShellSDKPSGalleryModules>Microsoft.PowerShell.Archive;Microsoft.PowerShell.ThreadJob</PowerShellSDKPSGalleryModules>
 </PropertyGroup>
 ```
@@ -207,11 +208,12 @@ This copies a minimal native launcher to `runtimes/<rid>/native/pwsh.exe` (or `p
 
 The source-built PowerShell runtime is patched so out-of-process jobs can use the selected runtime-native launcher when `$PSHOME/pwsh.exe` is not present. This lets `Start-Job` work in bundled-host scenarios that copy `pwsh.exe` under `runtimes/<rid>/native` instead of the app root.
 
-Use `PowerShellSDKCopyPhases` to decide where opted-in payloads are copied. The default is `Output;Publish`; set it to `Output` or `Publish` to disable the other phase. The package also has optional config, localized resource, and PSGallery module payloads:
+Use `PowerShellSDKCopyPhases` to decide where opted-in payloads are copied. The default is `Output;Publish`; set it to `Output` or `Publish` to disable the other phase. The package also has optional config, localized resource, XML documentation, and PSGallery module payloads:
 
 ```xml
 <PropertyGroup>
   <PowerShellSDKLocalizedResources>Copy</PowerShellSDKLocalizedResources>
+  <PowerShellSDKXmlDocumentation>Copy</PowerShellSDKXmlDocumentation>
   <PowerShellSDKPSGalleryModules>Microsoft.PowerShell.Archive;Microsoft.PowerShell.ThreadJob</PowerShellSDKPSGalleryModules>
 </PropertyGroup>
 ```
@@ -230,13 +232,14 @@ Use `PowerShellSDKCopyPhases` to decide where opted-in payloads are copied. The 
 | `PowerShellSDKConfigExecutionPolicy` | `Bypass` | PowerShell execution policy | Sets `Microsoft.PowerShell:ExecutionPolicy` in generated config. |
 | `PowerShellSDKConfigOverwriteExisting` | `false` | `true`, `false` | Replaces existing `powershell.config.json` only when `true`. |
 | `PowerShellSDKLocalizedResources` | `None` | `None`, `Copy` | Copies staged localized resource assemblies beside the apphost payload when the source package includes them. |
+| `PowerShellSDKXmlDocumentation` | `None` | `None`, `Copy` | Copies assembly XML documentation files such as `System.Management.Automation.xml` beside the apphost payload. These files stay in the package for IntelliSense even when copy is disabled. |
 | `PowerShellSDKPSGalleryModules` | `None` | `None`, `All`, or module list | Copies all staged PSGallery modules or a semicolon-delimited subset to `Modules`. |
 
 When passing semicolon-delimited values on the `dotnet` or `msbuild` command line, encode semicolons as `%3B`, such as `/p:PowerShellSDKCopyPhases=Output%3BPublish`.
 
-The apphost output is intended for running scripts with the core built-in modules from `$PSHOME/Modules`; it is not a full PowerShell distribution archive unless consumers deliberately enable optional payloads such as localized resources and PSGallery modules. PSGallery modules increase package and output size, include additional package-management or interactive functionality, and several are script modules subject to the bundled PowerShell execution policy.
+The apphost output is intended for running scripts with the core built-in modules from `$PSHOME/Modules`; it is not a full PowerShell distribution archive unless consumers deliberately enable optional payloads such as localized resources, XML documentation, and PSGallery modules. PSGallery modules increase package and output size, include additional package-management or interactive functionality, and several are script modules subject to the bundled PowerShell execution policy.
 
-The secondary PowerShell CLI workflow uses this same package-consumer path instead of rebuilding PowerShell from source. It creates a temporary .NET project, restores the pinned SDK package from the pinned package source or a workflow-built SDK artifact, enables root apphost and PSGallery module import, opts into localized resources when present, publishes self-contained for the matrix RID, removes the temporary host application files, validates the PowerShell layout, and archives the result as `.tar.gz` for every platform, including Windows. Windows archives additionally stage the matching `Microsoft.WindowsDesktop.App.Runtime.<rid>` payload so WPF/WinForms assemblies such as `PresentationFramework.dll`, `System.Windows.Forms.dll`, and `WindowsBase.dll` load from `$PSHOME`. For end-to-end dry runs outside `.github/workflows/release.yml`, pass `sdk_artifact_run_id` to `.github/workflows/powershell-cli.yml` so it downloads the `PowerShell-SDK-Release-X.Y.Z.R` artifact from a prior `.github/workflows/powershell-sdk.yml` run and repackages that workflow-built `.nupkg` instead of restoring from NuGet.org. If the artifact name does not include the SDK version, also pass `sdk_package_version`.
+The secondary PowerShell CLI workflow uses this same package-consumer path instead of rebuilding PowerShell from source. It creates a temporary .NET project, restores the pinned SDK package from the pinned package source or a workflow-built SDK artifact, enables root apphost, XML documentation, and PSGallery module import, opts into localized resources when present, publishes self-contained for the matrix RID, removes the temporary host application files, validates the PowerShell layout, and archives the result as `.tar.gz` for every platform, including Windows. Windows archives additionally stage the matching `Microsoft.WindowsDesktop.App.Runtime.<rid>` payload so WPF/WinForms assemblies such as `PresentationFramework.dll`, `System.Windows.Forms.dll`, and `WindowsBase.dll` load from `$PSHOME`. For end-to-end dry runs outside `.github/workflows/release.yml`, pass `sdk_artifact_run_id` to `.github/workflows/powershell-cli.yml` so it downloads the `PowerShell-SDK-Release-X.Y.Z.R` artifact from a prior `.github/workflows/powershell-sdk.yml` run and repackages that workflow-built `.nupkg` instead of restoring from NuGet.org. If the artifact name does not include the SDK version, also pass `sdk_package_version`.
 
 During NuGet packing, upstream `Microsoft.PowerShell.SDK` content file/reference metadata can emit NU5100/NU5131 package analysis warnings. The SDK workflow treats package validation as the source of truth: the generated sample must restore only the vendored PowerShell package ID, build, publish framework-dependent and self-contained outputs, execute `pwsh`, and load copied built-in modules.
 Generated source checkouts and build artifacts are not part of this repository.

--- a/eng/Microsoft.PowerShell.SDK.targets
+++ b/eng/Microsoft.PowerShell.SDK.targets
@@ -138,12 +138,14 @@
     <PowerShellSDKConfigExecutionPolicy Condition="'$(PowerShellSDKConfigExecutionPolicy)' == ''">Bypass</PowerShellSDKConfigExecutionPolicy>
     <PowerShellSDKConfigOverwriteExisting Condition="'$(PowerShellSDKConfigOverwriteExisting)' == ''">false</PowerShellSDKConfigOverwriteExisting>
     <PowerShellSDKLocalizedResources Condition="'$(PowerShellSDKLocalizedResources)' == ''">None</PowerShellSDKLocalizedResources>
+    <PowerShellSDKXmlDocumentation Condition="'$(PowerShellSDKXmlDocumentation)' == ''">None</PowerShellSDKXmlDocumentation>
     <PowerShellSDKPSGalleryModules Condition="'$(PowerShellSDKPSGalleryModules)' == ''">None</PowerShellSDKPSGalleryModules>
     <_PowerShellSDKAppHostLayoutValue>$([System.String]::Copy('$(PowerShellSDKAppHostLayout)').ToLowerInvariant())</_PowerShellSDKAppHostLayoutValue>
     <_PowerShellSDKAppHostImplementationValue>$([System.String]::Copy('$(PowerShellSDKAppHostImplementation)').ToLowerInvariant())</_PowerShellSDKAppHostImplementationValue>
     <_PowerShellSDKConfigValue>$([System.String]::Copy('$(PowerShellSDKConfig)').ToLowerInvariant())</_PowerShellSDKConfigValue>
     <_PowerShellSDKConfigOverwriteExistingValue>$([System.String]::Copy('$(PowerShellSDKConfigOverwriteExisting)').ToLowerInvariant())</_PowerShellSDKConfigOverwriteExistingValue>
     <_PowerShellSDKLocalizedResourcesValue>$([System.String]::Copy('$(PowerShellSDKLocalizedResources)').ToLowerInvariant())</_PowerShellSDKLocalizedResourcesValue>
+    <_PowerShellSDKXmlDocumentationValue>$([System.String]::Copy('$(PowerShellSDKXmlDocumentation)').ToLowerInvariant())</_PowerShellSDKXmlDocumentationValue>
     <_PowerShellSDKPSGalleryModulesValue>$([System.String]::Copy('$(PowerShellSDKPSGalleryModules)').ToLowerInvariant())</_PowerShellSDKPSGalleryModulesValue>
     <_PowerShellSDKSelfContainedValue>$([System.String]::Copy('$(SelfContained)').ToLowerInvariant())</_PowerShellSDKSelfContainedValue>
     <_PowerShellSDKCopyPhasesForItems>$([System.Text.RegularExpressions.Regex]::Replace('$(PowerShellSDKCopyPhases)', '%3[Bb]', ';'))</_PowerShellSDKCopyPhasesForItems>
@@ -162,6 +164,9 @@
     <_PowerShellSDKLocalizedResourcesEnabled Condition="'$(_PowerShellSDKLocalizedResourcesValue)' == 'copy'">true</_PowerShellSDKLocalizedResourcesEnabled>
     <_PowerShellSDKLocalizedResourcesCopyToOutputEnabled Condition="'$(_PowerShellSDKLocalizedResourcesEnabled)' == 'true' and '$(_PowerShellSDKCopyToOutputEnabled)' == 'true'">true</_PowerShellSDKLocalizedResourcesCopyToOutputEnabled>
     <_PowerShellSDKLocalizedResourcesCopyToPublishEnabled Condition="'$(_PowerShellSDKLocalizedResourcesEnabled)' == 'true' and '$(_PowerShellSDKCopyToPublishEnabled)' == 'true'">true</_PowerShellSDKLocalizedResourcesCopyToPublishEnabled>
+    <_PowerShellSDKXmlDocumentationEnabled Condition="'$(_PowerShellSDKXmlDocumentationValue)' == 'copy'">true</_PowerShellSDKXmlDocumentationEnabled>
+    <_PowerShellSDKXmlDocumentationCopyToOutputEnabled Condition="'$(_PowerShellSDKXmlDocumentationEnabled)' == 'true' and '$(_PowerShellSDKCopyToOutputEnabled)' == 'true'">true</_PowerShellSDKXmlDocumentationCopyToOutputEnabled>
+    <_PowerShellSDKXmlDocumentationCopyToPublishEnabled Condition="'$(_PowerShellSDKXmlDocumentationEnabled)' == 'true' and '$(_PowerShellSDKCopyToPublishEnabled)' == 'true'">true</_PowerShellSDKXmlDocumentationCopyToPublishEnabled>
     <_PowerShellSDKConfigEnabled Condition="'$(_PowerShellSDKConfigValue)' == 'copy' and '$(_PowerShellSDKAppHostEnabled)' == 'true'">true</_PowerShellSDKConfigEnabled>
     <_PowerShellSDKConfigCopyToOutputEnabled Condition="'$(_PowerShellSDKConfigEnabled)' == 'true' and '$(_PowerShellSDKCopyToOutputEnabled)' == 'true'">true</_PowerShellSDKConfigCopyToOutputEnabled>
     <_PowerShellSDKConfigCopyToPublishEnabled Condition="'$(_PowerShellSDKConfigEnabled)' == 'true' and '$(_PowerShellSDKCopyToPublishEnabled)' == 'true'">true</_PowerShellSDKConfigCopyToPublishEnabled>
@@ -181,6 +186,8 @@
            Text="PowerShellSDKConfigOverwriteExisting must be true or false." />
     <Error Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(PowerShellSDKLocalizedResources)', '^(?i:None|Copy)$')) != 'True'"
            Text="PowerShellSDKLocalizedResources must be None or Copy." />
+    <Error Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(PowerShellSDKXmlDocumentation)', '^(?i:None|Copy)$')) != 'True'"
+           Text="PowerShellSDKXmlDocumentation must be None or Copy." />
     <Error Condition="'$(_PowerShellSDKAppHostEnabled)' == 'true' and '$(_PowerShellSDKAppHostImplementationValue)' == 'dotnet'"
            Text="PowerShellSDKAppHostImplementation=DotNet is not available in this SDK package. Use Auto or MultiPwsh." />
   </Target>
@@ -195,6 +202,10 @@
     <ItemGroup>
       <NativeCopyLocalItems Remove="@(NativeCopyLocalItems)"
                             Condition="'%(NativeCopyLocalItems.NuGetPackageId)' == 'Devolutions.PowerShell.SDK' and $([System.String]::Copy('%(NativeCopyLocalItems.PathInPackage)').Contains('/native/'))" />
+      <RuntimeCopyLocalItems Remove="@(RuntimeCopyLocalItems)"
+                             Condition="'%(RuntimeCopyLocalItems.NuGetPackageId)' == 'Devolutions.PowerShell.SDK' and '%(RuntimeCopyLocalItems.Extension)' == '.xml'" />
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
+                               Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'Devolutions.PowerShell.SDK' and '%(ReferenceCopyLocalPaths.Extension)' == '.xml'" />
     </ItemGroup>
   </Target>
 
@@ -207,6 +218,8 @@
                              Condition="'$(_PowerShellSDKRuntimeNativeCopyToPublishEnabled)' == 'true' and '%(ResolvedFileToPublish.PowerShellSDKRuntimeNativeSharedPayload)' != 'true' and ('%(ResolvedFileToPublish.NuGetPackageId)' == 'Devolutions.PowerShell.SDK' or $([System.String]::Copy('%(ResolvedFileToPublish.FullPath)').Contains('\devolutions.powershell.sdk\')) or $([System.String]::Copy('%(ResolvedFileToPublish.FullPath)').Contains('/devolutions.powershell.sdk/'))) and ($([System.String]::Copy('%(ResolvedFileToPublish.PathInPackage)').Contains('/lib/')) or ($([System.String]::Copy('%(ResolvedFileToPublish.FullPath)').Contains('\runtimes\')) and $([System.String]::Copy('%(ResolvedFileToPublish.FullPath)').Contains('\lib\'))) or ($([System.String]::Copy('%(ResolvedFileToPublish.FullPath)').Contains('/runtimes/')) and $([System.String]::Copy('%(ResolvedFileToPublish.FullPath)').Contains('/lib/'))))" />
       <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)"
                              Condition="'$(_PowerShellSDKRuntimeNativeCopyToPublishEnabled)' == 'true' and '%(ResolvedFileToPublish.PowerShellSDKRuntimeNativeSharedPayload)' != 'true' and '%(ResolvedFileToPublish.Filename)%(ResolvedFileToPublish.Extension)' == 'System.Management.Automation.dll' and ('%(ResolvedFileToPublish.NuGetPackageId)' == 'PowerShellStandard.Library' or $([System.String]::Copy('%(ResolvedFileToPublish.FullPath)').Contains('\powershellstandard.library\')) or $([System.String]::Copy('%(ResolvedFileToPublish.FullPath)').Contains('/powershellstandard.library/')))" />
+      <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)"
+                             Condition="'%(ResolvedFileToPublish.PowerShellSDKXmlDocumentation)' != 'true' and '%(ResolvedFileToPublish.Extension)' == '.xml' and ('%(ResolvedFileToPublish.NuGetPackageId)' == 'Devolutions.PowerShell.SDK' or $([System.String]::Copy('%(ResolvedFileToPublish.FullPath)').Contains('\devolutions.powershell.sdk\')) or $([System.String]::Copy('%(ResolvedFileToPublish.FullPath)').Contains('/devolutions.powershell.sdk/')))" />
     </ItemGroup>
   </Target>
 
@@ -245,7 +258,8 @@
     <ItemGroup>
       <_PowerShellSDKAppHostFile Include="$(_PowerShellSDKAppHostSourceDir)**/*" />
       <_PowerShellSDKModuleFile Include="$(_PowerShellSDKModuleSourceDir)**/*" />
-      <_PowerShellSDKAppHostRuntimeFile Include="$(_PowerShellSDKAppHostRuntimeSourceDir)*.dll;$(_PowerShellSDKAppHostRuntimeSourceDir)*.xml" />
+      <_PowerShellSDKAppHostRuntimeFile Include="$(_PowerShellSDKAppHostRuntimeSourceDir)*.dll" />
+      <_PowerShellSDKAppHostXmlDocumentationFile Include="$(_PowerShellSDKAppHostRuntimeSourceDir)*.xml" />
       <_PowerShellSDKAppHostCompanionFile Include="$(_PowerShellSDKAppHostRuntimeSourceDir)*.config" />
       <_PowerShellSDKAppHostLocalizedResourceFile Include="$(_PowerShellSDKAppHostLocalizedResourceSourceDir)**/*"
                                                   Condition="Exists('$(_PowerShellSDKAppHostLocalizedResourceSourceDir)')" />
@@ -349,7 +363,8 @@
     <ItemGroup>
       <_PowerShellSDKRuntimeNativeSharedAppHostFile Include="$(_PowerShellSDKRuntimeNativeSharedAppHostSourceDir)pwsh.dll;$(_PowerShellSDKRuntimeNativeSharedAppHostSourceDir)pwsh.runtimeconfig.json" />
       <_PowerShellSDKRuntimeNativeSharedModuleFile Include="$(_PowerShellSDKRuntimeNativeSharedModuleSourceDir)**/*" />
-      <_PowerShellSDKRuntimeNativeSharedRuntimeFile Include="$(_PowerShellSDKRuntimeNativeSharedRuntimeSourceDir)*.dll;$(_PowerShellSDKRuntimeNativeSharedRuntimeSourceDir)*.xml" />
+      <_PowerShellSDKRuntimeNativeSharedRuntimeFile Include="$(_PowerShellSDKRuntimeNativeSharedRuntimeSourceDir)*.dll" />
+      <_PowerShellSDKRuntimeNativeSharedXmlDocumentationFile Include="$(_PowerShellSDKRuntimeNativeSharedRuntimeSourceDir)*.xml" />
       <_PowerShellSDKRuntimeNativeSharedCompanionFile Include="$(_PowerShellSDKRuntimeNativeSharedRuntimeSourceDir)*.config" />
       <_PowerShellSDKRuntimeNativeSharedLocalizedResourceFile Include="$(_PowerShellSDKRuntimeNativeSharedLocalizedResourceSourceDir)**/*"
                                                              Condition="Exists('$(_PowerShellSDKRuntimeNativeSharedLocalizedResourceSourceDir)')" />
@@ -460,6 +475,16 @@
           Condition="'@(_PowerShellSDKAppHostLocalizedResourceFile)' != ''" />
   </Target>
 
+  <Target Name="PowerShellSDKCopyAppHostXmlDocumentationToOutput"
+          DependsOnTargets="_PowerShellSDKResolveAppHost"
+          AfterTargets="PowerShellSDKCopyAppHostToOutput"
+          Condition="'$(_PowerShellSDKXmlDocumentationCopyToOutputEnabled)' == 'true' and '$(_PowerShellSDKRootAppHostEnabled)' == 'true'">
+    <Copy SourceFiles="@(_PowerShellSDKAppHostXmlDocumentationFile)"
+          DestinationFiles="@(_PowerShellSDKAppHostXmlDocumentationFile->'$(OutDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true"
+          Condition="'@(_PowerShellSDKAppHostXmlDocumentationFile)' != ''" />
+  </Target>
+
   <Target Name="PowerShellSDKCopyRuntimeNativeAppHostsToOutput"
           DependsOnTargets="_PowerShellSDKResolveRuntimeNativeAppHosts"
           AfterTargets="CopyFilesToOutputDirectory"
@@ -526,6 +551,20 @@
           Condition="'@(_PowerShellSDKRuntimeNativeSharedLocalizedResourceFile)' != ''" />
   </Target>
 
+  <Target Name="PowerShellSDKCopyRuntimeNativeXmlDocumentationToOutput"
+          DependsOnTargets="_PowerShellSDKResolveRuntimeNativeAppHosts"
+          AfterTargets="PowerShellSDKCopyRuntimeNativeAppHostsToOutput"
+          Condition="'$(_PowerShellSDKXmlDocumentationCopyToOutputEnabled)' == 'true' and '$(_PowerShellSDKRuntimeNativeAppHostEnabled)' == 'true'">
+    <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeSharedXmlDocumentationFile)"
+          DestinationFiles="@(_PowerShellSDKRuntimeNativeSharedXmlDocumentationFile->'$(OutDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true"
+          Condition="'@(_PowerShellSDKRuntimeNativeSharedXmlDocumentationFile)' != ''" />
+    <Copy SourceFiles="@(_PowerShellSDKRuntimeNativeSharedXmlDocumentationFile)"
+          DestinationFiles="@(_PowerShellSDKRuntimeNativeSharedXmlDocumentationFile->'$(OutDir)runtimes/$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)/lib/$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)/%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true"
+          Condition="'@(_PowerShellSDKRuntimeNativeSharedXmlDocumentationFile)' != ''" />
+  </Target>
+
   <Target Name="PowerShellSDKCopyPSGalleryModulesToOutput"
           DependsOnTargets="_PowerShellSDKResolvePSGalleryModules"
           AfterTargets="CopyFilesToOutputDirectory"
@@ -589,6 +628,16 @@
           Condition="'@(_PowerShellSDKAppHostLocalizedResourceFile)' != ''" />
   </Target>
 
+  <Target Name="PowerShellSDKCopyAppHostXmlDocumentationToPublish"
+          DependsOnTargets="_PowerShellSDKResolveAppHost"
+          AfterTargets="Publish"
+          Condition="'$(_PowerShellSDKXmlDocumentationCopyToPublishEnabled)' == 'true' and '$(_PowerShellSDKRootAppHostEnabled)' == 'true'">
+    <Copy SourceFiles="@(_PowerShellSDKAppHostXmlDocumentationFile)"
+          DestinationFiles="@(_PowerShellSDKAppHostXmlDocumentationFile->'$(PublishDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true"
+          Condition="'@(_PowerShellSDKAppHostXmlDocumentationFile)' != ''" />
+  </Target>
+
   <Target Name="PowerShellSDKAddRuntimeNativeAppHostsToPublish"
           DependsOnTargets="_PowerShellSDKResolveRuntimeNativeAppHosts"
           BeforeTargets="ComputeFilesToPublish"
@@ -647,6 +696,28 @@
           DestinationFiles="@(_PowerShellSDKRuntimeNativeSharedLocalizedResourceFile->'$(PublishDir)%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true"
           Condition="'@(_PowerShellSDKRuntimeNativeSharedLocalizedResourceFile)' != ''" />
+  </Target>
+
+  <Target Name="PowerShellSDKAddRuntimeNativeXmlDocumentationToPublish"
+          DependsOnTargets="_PowerShellSDKResolveRuntimeNativeAppHosts"
+          BeforeTargets="ComputeFilesToPublish"
+          Condition="'$(_PowerShellSDKXmlDocumentationCopyToPublishEnabled)' == 'true' and '$(_PowerShellSDKRuntimeNativeCopyToPublishEnabled)' == 'true'">
+    <ItemGroup>
+      <ResolvedFileToPublish Include="@(_PowerShellSDKRuntimeNativeSharedXmlDocumentationFile)"
+                             Condition="'@(_PowerShellSDKRuntimeNativeSharedXmlDocumentationFile)' != ''">
+        <RelativePath>%(_PowerShellSDKRuntimeNativeSharedXmlDocumentationFile.Filename)%(_PowerShellSDKRuntimeNativeSharedXmlDocumentationFile.Extension)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <PowerShellSDKRuntimeNativeSharedPayload>true</PowerShellSDKRuntimeNativeSharedPayload>
+        <PowerShellSDKXmlDocumentation>true</PowerShellSDKXmlDocumentation>
+      </ResolvedFileToPublish>
+      <ResolvedFileToPublish Include="@(_PowerShellSDKRuntimeNativeSharedXmlDocumentationFile)"
+                             Condition="'@(_PowerShellSDKRuntimeNativeSharedXmlDocumentationFile)' != ''">
+        <RelativePath>runtimes\$(_PowerShellSDKRuntimeNativeSharedPayloadGroup)\lib\$(_PowerShellSDKRuntimeNativeSharedPayloadTargetFramework)\%(_PowerShellSDKRuntimeNativeSharedXmlDocumentationFile.Filename)%(_PowerShellSDKRuntimeNativeSharedXmlDocumentationFile.Extension)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <PowerShellSDKRuntimeNativeSharedPayload>true</PowerShellSDKRuntimeNativeSharedPayload>
+        <PowerShellSDKXmlDocumentation>true</PowerShellSDKXmlDocumentation>
+      </ResolvedFileToPublish>
+    </ItemGroup>
   </Target>
 
   <Target Name="PowerShellSDKAddPSGalleryModulesToPublish"

--- a/eng/New-PowerShellDistroArchive.ps1
+++ b/eng/New-PowerShellDistroArchive.ps1
@@ -837,6 +837,7 @@ try {
     <PowerShellSDKAppHostLayout>Root</PowerShellSDKAppHostLayout>
     <PowerShellSDKAppHostRuntimeIdentifier>$EscapedRuntimeIdentifier</PowerShellSDKAppHostRuntimeIdentifier>
     <PowerShellSDKPSGalleryModules>All</PowerShellSDKPSGalleryModules>
+    <PowerShellSDKXmlDocumentation>Copy</PowerShellSDKXmlDocumentation>
     <PowerShellSDKConfig>$EscapedConfigMode</PowerShellSDKConfig>
     <PowerShellSDKConfigExecutionPolicy>Bypass</PowerShellSDKConfigExecutionPolicy>
     <PowerShellSDKConfigOverwriteExisting>true</PowerShellSDKConfigOverwriteExisting>

--- a/eng/Validate-PowerShellSdkPackage.ps1
+++ b/eng/Validate-PowerShellSdkPackage.ps1
@@ -692,6 +692,115 @@ function Assert-LocalizedResourceFilesUnchanged {
   }
 }
 
+function Get-XmlDocumentationFileNames {
+  param(
+    [Parameter(Mandatory)]
+    [string] $RestoredSdkPath,
+
+    [Parameter(Mandatory)]
+    [string] $RuntimeAssetGroup,
+
+    [Parameter(Mandatory)]
+    [string] $TargetFramework
+  )
+
+  $RuntimeXmlRoot = Join-Path $RestoredSdkPath "runtimes/$RuntimeAssetGroup/lib/$TargetFramework"
+  $PreferredNames = @(
+    'System.Management.Automation.xml',
+    'Microsoft.PowerShell.Commands.Management.xml'
+  )
+  $Found = @()
+  foreach ($Name in $PreferredNames) {
+    if (Test-Path (Join-Path $RuntimeXmlRoot $Name) -PathType Leaf) {
+      $Found += $Name
+    }
+  }
+  if ($Found.Count -eq 0) {
+    throw "SDK package is missing expected XML documentation files under $RuntimeXmlRoot"
+  }
+
+  return $Found
+}
+
+function Get-XmlDocumentationOutputRelativePaths {
+  param(
+    [Parameter(Mandatory)]
+    [string[]] $FileNames,
+
+    [string] $RuntimeAssetGroup,
+
+    [string] $TargetFramework,
+
+    [bool] $IncludeRuntimeLib = $false
+  )
+
+  $RelativePaths = @($FileNames)
+  if ($IncludeRuntimeLib) {
+    foreach ($Name in $FileNames) {
+      $RelativePaths += "runtimes/$RuntimeAssetGroup/lib/$TargetFramework/$Name"
+    }
+  }
+
+  return $RelativePaths
+}
+
+function Assert-XmlDocumentationFiles {
+  param(
+    [Parameter(Mandatory)]
+    [string] $Directory,
+
+    [Parameter(Mandatory)]
+    [string[]] $RelativePaths,
+
+    [Parameter(Mandatory)]
+    [bool] $Present,
+
+    [Parameter(Mandatory)]
+    [string] $Description
+  )
+
+  foreach ($RelativePath in $RelativePaths) {
+    $Path = Join-Path $Directory ($RelativePath -replace '/', [IO.Path]::DirectorySeparatorChar)
+    if ($Present) {
+      if (-not (Test-Path $Path -PathType Leaf)) {
+        throw "$Description is missing expected XML documentation file: $Path"
+      }
+    }
+    elseif (Test-Path $Path -PathType Leaf) {
+      throw "$Description unexpectedly contains XML documentation file: $Path"
+    }
+  }
+}
+
+function Assert-XmlDocumentationContentMatches {
+  param(
+    [Parameter(Mandatory)]
+    [string] $RestoredSdkPath,
+
+    [Parameter(Mandatory)]
+    [string] $Directory,
+
+    [Parameter(Mandatory)]
+    [string] $RuntimeAssetGroup,
+
+    [Parameter(Mandatory)]
+    [string] $TargetFramework,
+
+    [Parameter(Mandatory)]
+    [string[]] $RelativePaths,
+
+    [Parameter(Mandatory)]
+    [string] $Description
+  )
+
+  foreach ($RelativePath in $RelativePaths) {
+    $FileName = Split-Path $RelativePath -Leaf
+    $ExpectedPath = Join-Path $RestoredSdkPath "runtimes/$RuntimeAssetGroup/lib/$TargetFramework/$FileName"
+    $ActualPath = Join-Path $Directory ($RelativePath -replace '/', [IO.Path]::DirectorySeparatorChar)
+    Assert-FileContentMatches -ExpectedPath $ExpectedPath -ActualPath $ActualPath -Description "$Description ($RelativePath)"
+  }
+}
+
 function Invoke-RuntimeNativeOverwriteProbe {
   param(
     [Parameter(Mandatory)]
@@ -971,11 +1080,14 @@ function Invoke-AppHostLayoutMatrixProbe {
   )
 
   $Layouts = @(
-    [pscustomobject]@{ Name = 'None'; AppHostLayout = ''; ExpectRootAppHost = $false; ExpectRuntimeNativeAppHost = $false; CopyPSGalleryModules = $false; CopyLocalizedResources = $false },
-    [pscustomobject]@{ Name = 'Root'; AppHostLayout = 'Root'; ExpectRootAppHost = $true; ExpectRuntimeNativeAppHost = $false; CopyPSGalleryModules = $false; CopyLocalizedResources = $true },
-    [pscustomobject]@{ Name = 'RuntimeNative'; AppHostLayout = 'RuntimeNative'; ExpectRootAppHost = $false; ExpectRuntimeNativeAppHost = $true; CopyPSGalleryModules = $true; CopyLocalizedResources = $false },
-    [pscustomobject]@{ Name = 'Both'; AppHostLayout = 'Both'; ExpectRootAppHost = $true; ExpectRuntimeNativeAppHost = $true; CopyPSGalleryModules = $true; CopyLocalizedResources = $false }
+    [pscustomobject]@{ Name = 'None'; AppHostLayout = ''; ExpectRootAppHost = $false; ExpectRuntimeNativeAppHost = $false; CopyPSGalleryModules = $false; CopyLocalizedResources = $false; CopyXmlDocumentation = $false },
+    [pscustomobject]@{ Name = 'Root'; AppHostLayout = 'Root'; ExpectRootAppHost = $true; ExpectRuntimeNativeAppHost = $false; CopyPSGalleryModules = $false; CopyLocalizedResources = $true; CopyXmlDocumentation = $true },
+    [pscustomobject]@{ Name = 'RuntimeNative'; AppHostLayout = 'RuntimeNative'; ExpectRootAppHost = $false; ExpectRuntimeNativeAppHost = $true; CopyPSGalleryModules = $true; CopyLocalizedResources = $false; CopyXmlDocumentation = $false },
+    [pscustomobject]@{ Name = 'Both'; AppHostLayout = 'Both'; ExpectRootAppHost = $true; ExpectRuntimeNativeAppHost = $true; CopyPSGalleryModules = $true; CopyLocalizedResources = $false; CopyXmlDocumentation = $false }
   )
+
+  $XmlDocumentationFileNames = Get-XmlDocumentationFileNames -RestoredSdkPath $RestoredSdkPath -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework
+  $XmlDocumentationRootRelativePaths = Get-XmlDocumentationOutputRelativePaths -FileNames $XmlDocumentationFileNames
 
   foreach ($Layout in $Layouts) {
     $ProbeDirectory = Join-Path $ValidationRoot "sample-layout-$($Layout.Name.ToLowerInvariant())"
@@ -1090,6 +1202,7 @@ if (ps.HadErrors)
 
       Assert-SharedPowerShellRuntimeLibPreserved -RestoredSdkPath $RestoredSdkPath -Directory $ProbeOutputDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description $Description
       Assert-AppDepsRuntimeTargetsPreserved -Directory $ProbeOutputDirectory -AssemblyName $AssemblyName -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description $Description
+      Assert-XmlDocumentationFiles -Directory $ProbeOutputDirectory -RelativePaths $XmlDocumentationRootRelativePaths -Present $false -Description "$Description before XML documentation opt-in"
 
       if ($Layout.AppHostLayout) {
         Assert-PowerShellConfig -Directory $ProbeOutputDirectory -ExpectedExecutionPolicy 'Bypass' -Description $Description
@@ -1109,6 +1222,18 @@ if (ps.HadErrors)
         )
         $LocalizedResourceOutputAfter = @(Get-LocalizedResourceFileSnapshot -Directory $ProbeOutputDirectory)
         Assert-LocalizedResourceFilesUnchanged -ExpectedSnapshot $LocalizedResourceOutputBefore -ActualSnapshot $LocalizedResourceOutputAfter -Description "$Description localized resources output opt-in"
+      }
+      if ($Layout.CopyXmlDocumentation) {
+        Invoke-DotNet @(
+          'msbuild',
+          $ProjectPath,
+          '-nologo',
+          '-verbosity:minimal',
+          '-t:PowerShellSDKCopyAppHostXmlDocumentationToOutput',
+          '/p:PowerShellSDKXmlDocumentation=Copy'
+        )
+        Assert-XmlDocumentationFiles -Directory $ProbeOutputDirectory -RelativePaths $XmlDocumentationRootRelativePaths -Present $true -Description "$Description with XML documentation opt-in"
+        Assert-XmlDocumentationContentMatches -RestoredSdkPath $RestoredSdkPath -Directory $ProbeOutputDirectory -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -RelativePaths $XmlDocumentationRootRelativePaths -Description "$Description XML documentation opt-in"
       }
       if ($Layout.ExpectRootAppHost) {
         Assert-AppHostOutput -Directory $ProbeOutputDirectory -ExecutableName $ExecutableName -Description $Description
@@ -1167,6 +1292,46 @@ if (ps.HadErrors)
         $LocalizedResourcePublishAfter = @(Get-LocalizedResourceFileSnapshot -Directory $LocalizedPublishDirectory)
         Assert-AppHostOutput -Directory $LocalizedPublishDirectory -ExecutableName $ExecutableName -Description "$($Layout.Name) layout localized resource publish output"
         Assert-LocalizedResourceFilesUnchanged -ExpectedSnapshot $LocalizedResourcePublishBefore -ActualSnapshot $LocalizedResourcePublishAfter -Description "$($Layout.Name) layout localized resource publish opt-in"
+      }
+
+      if ($Layout.CopyXmlDocumentation) {
+        $XmlPublishDirectory = Join-Path $ProbeDirectory (Join-Path 'bin' (Join-Path 'Release' (Join-Path $SampleTargetFramework (Join-Path $CurrentRuntimeIdentifier 'publish-xml-documentation'))))
+        Remove-Item -LiteralPath $XmlPublishDirectory -Recurse -Force -ErrorAction SilentlyContinue
+        Invoke-DotNet @(
+          'publish',
+          $ProjectPath,
+          '--nologo',
+          '--verbosity',
+          'minimal',
+          '-c',
+          'Release',
+          '-r',
+          $CurrentRuntimeIdentifier,
+          '--self-contained',
+          'false',
+          '-o',
+          $XmlPublishDirectory
+        )
+        Assert-XmlDocumentationFiles -Directory $XmlPublishDirectory -RelativePaths $XmlDocumentationRootRelativePaths -Present $false -Description "$($Layout.Name) layout publish output before XML documentation opt-in"
+        Invoke-DotNet @(
+          'publish',
+          $ProjectPath,
+          '--nologo',
+          '--verbosity',
+          'minimal',
+          '-c',
+          'Release',
+          '-r',
+          $CurrentRuntimeIdentifier,
+          '--self-contained',
+          'false',
+          '-o',
+          $XmlPublishDirectory,
+          '/p:PowerShellSDKXmlDocumentation=Copy'
+        )
+        Assert-AppHostOutput -Directory $XmlPublishDirectory -ExecutableName $ExecutableName -Description "$($Layout.Name) layout XML documentation publish output"
+        Assert-XmlDocumentationFiles -Directory $XmlPublishDirectory -RelativePaths $XmlDocumentationRootRelativePaths -Present $true -Description "$($Layout.Name) layout XML documentation publish output"
+        Assert-XmlDocumentationContentMatches -RestoredSdkPath $RestoredSdkPath -Directory $XmlPublishDirectory -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -RelativePaths $XmlDocumentationRootRelativePaths -Description "$($Layout.Name) layout XML documentation publish output"
       }
 
       $ProbeOutput = & dotnet run --project $ProjectPath --no-build
@@ -1770,11 +1935,14 @@ foreach (PSObject result in ps.Invoke())
   } else {
     Write-Host "SDK package does not include localized resources for '$RuntimeAssetGroup/$TargetFramework'; validating PowerShellSDKLocalizedResources=Copy as a no-op."
   }
+  $XmlDocumentationFileNames = Get-XmlDocumentationFileNames -RestoredSdkPath $RestoredSdkPath -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework
+  $XmlDocumentationOutputRelativePaths = Get-XmlDocumentationOutputRelativePaths -FileNames $XmlDocumentationFileNames -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -IncludeRuntimeLib $true
 
   Invoke-DotNet @('build', $ProjectPath, '--no-restore', '--nologo', '--verbosity', 'minimal')
 
   $OutputDirectory = Join-Path $SampleDirectory (Join-Path 'bin' (Join-Path 'Debug' (Join-Path $SampleTargetFramework $RuntimeIdentifier)))
   Assert-SharedPowerShellOutput -Directory $OutputDirectory -SelfContained $FrameworkDependentAppHostSelfContained -Description 'Sample app output'
+  Assert-XmlDocumentationFiles -Directory $OutputDirectory -RelativePaths $XmlDocumentationOutputRelativePaths -Present $false -Description 'Sample app output before XML documentation opt-in'
   Assert-PowerShellConfig -Directory $OutputDirectory -ExpectedExecutionPolicy 'Bypass' -Description 'Sample app output'
   Assert-NoRootRuntimeNativeAppHostOutput -Directory $OutputDirectory -ExecutableName $ExecutableName -Description 'Sample app output'
   Assert-SharedPowerShellRuntimeLibPreserved -RestoredSdkPath $RestoredSdkPath -Directory $OutputDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'Sample app output'
@@ -1840,6 +2008,17 @@ foreach (PSObject result in ps.Invoke())
     Assert-FileContentMatches -ExpectedPath $RepresentativeLocalizedResourcePackagePath -ActualPath $OutputLocalizedResourcePath -Description 'Sample app output localized resource opt-in'
   }
 
+  Invoke-DotNet @(
+    'msbuild',
+    $ProjectPath,
+    '-nologo',
+    '-verbosity:minimal',
+    '-t:PowerShellSDKCopyRuntimeNativeXmlDocumentationToOutput',
+    '/p:PowerShellSDKXmlDocumentation=Copy'
+  )
+  Assert-XmlDocumentationFiles -Directory $OutputDirectory -RelativePaths $XmlDocumentationOutputRelativePaths -Present $true -Description 'Sample app output with XML documentation opt-in'
+  Assert-XmlDocumentationContentMatches -RestoredSdkPath $RestoredSdkPath -Directory $OutputDirectory -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -RelativePaths $XmlDocumentationOutputRelativePaths -Description 'Sample app output XML documentation opt-in'
+
   if (-not $SkipRuntimeExecution) {
     $AppOutput = & dotnet run --project $ProjectPath --no-build
     if ($LASTEXITCODE -ne 0) {
@@ -1857,6 +2036,7 @@ foreach (PSObject result in ps.Invoke())
 
   $PublishDirectory = Join-Path $SampleDirectory (Join-Path 'bin' (Join-Path 'Release' (Join-Path $SampleTargetFramework (Join-Path $RuntimeIdentifier 'publish'))))
   Assert-SharedPowerShellOutput -Directory $PublishDirectory -SelfContained $true -Description 'Sample self-contained publish output'
+  Assert-XmlDocumentationFiles -Directory $PublishDirectory -RelativePaths $XmlDocumentationOutputRelativePaths -Present $false -Description 'Sample self-contained publish output before XML documentation opt-in'
   Assert-PowerShellConfig -Directory $PublishDirectory -ExpectedExecutionPolicy 'Bypass' -Description 'Sample self-contained publish output'
   Assert-NoRootRuntimeNativeAppHostOutput -Directory $PublishDirectory -ExecutableName $ExecutableName -Description 'Sample self-contained publish output'
   Assert-SharedPowerShellRuntimeLibPreserved -RestoredSdkPath $RestoredSdkPath -Directory $PublishDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'Sample self-contained publish output'
@@ -1876,6 +2056,7 @@ foreach (PSObject result in ps.Invoke())
   Remove-Item $FrameworkDependentPublishDirectory -Recurse -Force -ErrorAction SilentlyContinue
   Invoke-DotNet @('publish', $ProjectPath, '--nologo', '--verbosity', 'minimal', '-c', 'Release', '-r', $RuntimeIdentifier, '--self-contained', 'false', '-o', $FrameworkDependentPublishDirectory)
   Assert-SharedPowerShellOutput -Directory $FrameworkDependentPublishDirectory -SelfContained $FrameworkDependentAppHostSelfContained -Description 'Sample framework-dependent publish output'
+  Assert-XmlDocumentationFiles -Directory $FrameworkDependentPublishDirectory -RelativePaths $XmlDocumentationOutputRelativePaths -Present $false -Description 'Sample framework-dependent publish output before XML documentation opt-in'
   Assert-PowerShellConfig -Directory $FrameworkDependentPublishDirectory -ExpectedExecutionPolicy 'Bypass' -Description 'Sample framework-dependent publish output'
   Assert-NoRootRuntimeNativeAppHostOutput -Directory $FrameworkDependentPublishDirectory -ExecutableName $ExecutableName -Description 'Sample framework-dependent publish output'
   Assert-SharedPowerShellRuntimeLibPreserved -RestoredSdkPath $RestoredSdkPath -Directory $FrameworkDependentPublishDirectory -SourceBuiltPackageAssetEntries $SourceBuiltPackageAssetEntries -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -Description 'Sample framework-dependent publish output'
@@ -1969,6 +2150,28 @@ foreach (PSObject result in ps.Invoke())
     Assert-LocalizedResourcePresent -Directory $LocalizedPublishDirectory -RelativePath $RepresentativeLocalizedResourcePath -Description 'Sample localized resource publish output'
     Assert-FileContentMatches -ExpectedPath $RepresentativeLocalizedResourcePackagePath -ActualPath (Join-Path $LocalizedPublishDirectory $RepresentativeLocalizedResourcePath) -Description 'Sample localized resource publish output'
   }
+
+  $XmlPublishDirectory = Join-Path $SampleDirectory (Join-Path 'bin' (Join-Path 'Release' (Join-Path $SampleTargetFramework (Join-Path $RuntimeIdentifier 'publish-xml-documentation'))))
+  Remove-Item $XmlPublishDirectory -Recurse -Force -ErrorAction SilentlyContinue
+  Invoke-DotNet @(
+    'publish',
+    $ProjectPath,
+    '--nologo',
+    '--verbosity',
+    'minimal',
+    '-c',
+    'Release',
+    '-r',
+    $RuntimeIdentifier,
+    '--self-contained',
+    'false',
+    '-o',
+    $XmlPublishDirectory,
+    '/p:PowerShellSDKXmlDocumentation=Copy'
+  )
+  Assert-SharedPowerShellOutput -Directory $XmlPublishDirectory -SelfContained $FrameworkDependentAppHostSelfContained -Description 'Sample XML documentation publish output'
+  Assert-XmlDocumentationFiles -Directory $XmlPublishDirectory -RelativePaths $XmlDocumentationOutputRelativePaths -Present $true -Description 'Sample XML documentation publish output'
+  Assert-XmlDocumentationContentMatches -RestoredSdkPath $RestoredSdkPath -Directory $XmlPublishDirectory -RuntimeAssetGroup $RuntimeAssetGroup -TargetFramework $TargetFramework -RelativePaths $XmlDocumentationOutputRelativePaths -Description 'Sample XML documentation publish output'
 
   Write-Host "Validated $PackageId $PackageVersion from $($Package.FullName)"
   if ($SkipRuntimeExecution) {

--- a/eng/Validate-PowerShellSdkPackage.ps1
+++ b/eng/Validate-PowerShellSdkPackage.ps1
@@ -705,16 +705,19 @@ function Get-XmlDocumentationFileNames {
   )
 
   $RuntimeXmlRoot = Join-Path $RestoredSdkPath "runtimes/$RuntimeAssetGroup/lib/$TargetFramework"
-  $PreferredNames = @(
-    'System.Management.Automation.xml',
-    'Microsoft.PowerShell.Commands.Management.xml'
-  )
-  $Found = @()
-  foreach ($Name in $PreferredNames) {
-    if (Test-Path (Join-Path $RuntimeXmlRoot $Name) -PathType Leaf) {
-      $Found += $Name
-    }
+  if (-not (Test-Path -LiteralPath $RuntimeXmlRoot -PathType Container)) {
+    throw "SDK package is missing expected XML documentation directory $RuntimeXmlRoot"
   }
+
+  $Found = @(
+    Get-ChildItem -LiteralPath $RuntimeXmlRoot -Filter '*.xml' -File |
+      Where-Object {
+        $_.Extension -eq '.xml' -and
+        $_.Name -notlike '*-Help.xml'
+      } |
+      Select-Object -ExpandProperty Name |
+      Sort-Object
+  )
   if ($Found.Count -eq 0) {
     throw "SDK package is missing expected XML documentation files under $RuntimeXmlRoot"
   }


### PR DESCRIPTION
Add a consumer MSBuild property that controls whether assembly XML documentation files (`System.Management.Automation.xml` and siblings) are copied into app output from `Devolutions.PowerShell.SDK`.

The files stay in the nupkg for IntelliSense. Copy is opt-in, matching `PowerShellSDKLocalizedResources`:

```xml
<PowerShellSDKXmlDocumentation>Copy</PowerShellSDKXmlDocumentation>
```

Default is `None`. CLI archives set `Copy` so distro payloads still include the docs. Validation now asserts they are absent by default and present when opted in.