### PR TITLE
Bump PowerShell to 7.6.6

### DIFF
--- a/.github/workflows/powershell-cli.yml
+++ b/.github/workflows/powershell-cli.yml
@@ -64,13 +64,13 @@ permissions:
   actions: read
   contents: read
 env:
-  POWERSHELL_VERSION: "7.6.5"
-  POWERSHELL_RELEASE_TAG: "v7.6.5"
-  POWERSHELL_UPSTREAM_TAG: "upstream/v7.6.5"
+  POWERSHELL_VERSION: "7.6.6"
+  POWERSHELL_RELEASE_TAG: "v7.6.6"
+  POWERSHELL_UPSTREAM_TAG: "upstream/v7.6.6"
   POWERSHELL_SOURCE_REPOSITORY: ${{ github.repository }}
-  POWERSHELL_SOURCE_REF: "downstream/v7.6.5"
+  POWERSHELL_SOURCE_REF: "downstream/v7.6.6"
   SDK_PACKAGE_ID: "Devolutions.PowerShell.SDK"
-  SDK_PACKAGE_VERSION: "7.6.5.0"
+  SDK_PACKAGE_VERSION: "7.6.6.0"
   SDK_PACKAGE_REVISION: "0"
   SDK_PACKAGE_SOURCE: "https://api.nuget.org/v3/index.json"
 jobs:

--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -106,11 +106,11 @@ permissions:
   contents: read
 
 env:
-  POWERSHELL_VERSION: "7.6.5"
-  POWERSHELL_RELEASE_TAG: "v7.6.5"
-  POWERSHELL_UPSTREAM_TAG: "upstream/v7.6.5"
+  POWERSHELL_VERSION: "7.6.6"
+  POWERSHELL_RELEASE_TAG: "v7.6.6"
+  POWERSHELL_UPSTREAM_TAG: "upstream/v7.6.6"
   POWERSHELL_SOURCE_REPOSITORY: ${{ github.repository }}
-  POWERSHELL_SOURCE_REF: "downstream/v7.6.5"
+  POWERSHELL_SOURCE_REF: "downstream/v7.6.6"
   POWERSHELL_VENDOR_NAME: "Devolutions"
   SDK_VENDOR_NAME: "Devolutions"
   SDK_PACKAGE_ID: "Devolutions.PowerShell.SDK"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "pwsh-src"]
 	path = pwsh-src
 	url = ./
-	branch = downstream/v7.6.5
+	branch = downstream/v7.6.6

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ The local script writes under `output\local-sdk\<rid>\` and produces a single-RI
 
 | Component | Version |
 | --- | --- |
-| PowerShell upstream release | `7.6.5` / `v7.6.5` |
-| PowerShell downstream source ref | `downstream/v7.6.5` based on `upstream/v7.6.5` |
+| PowerShell upstream release | `7.6.6` / `v7.6.6` |
+| PowerShell downstream source ref | `downstream/v7.6.6` based on `upstream/v7.6.6` |
 | PowerShell target framework | `net10.0` |
-| PowerShell SDK package | `Devolutions.PowerShell.SDK` / `7.6.5.0` workflow default; `7.6.3.2` latest published package |
+| PowerShell SDK package | `Devolutions.PowerShell.SDK` / `7.6.6.0` workflow default; `7.6.3.2` latest published package |
 | Latest downstream release tag | `v7.6.3.2` |
 | Latest PowerShell CLI release assets | `PowerShell-7.6.3-<os>-<arch>.tar.gz` for Windows, macOS, and Linux on x64 and arm64 |
 | PowerShell SDK package source | `https://api.nuget.org/v3/index.json` |


### PR DESCRIPTION
## Summary
- update workflow, submodule, and README pins to PowerShell 7.6.6
- pin `pwsh-src` to the published `downstream/v7.6.6` patch branch based on `upstream/v7.6.6`
- port the four 7.6.5 downstream patches onto the new upstream tag

## Validation
- PowerShell pin audit with the initialized submodule
- Yayaml parsing for both PowerShell workflows
- source ancestry and git diff checks
- local win-x64 SDK package build and validation (`Devolutions.PowerShell.SDK` 7.6.6.0)